### PR TITLE
fix(rust-sdk): expose all transaction-related types

### DIFF
--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -29,6 +29,10 @@ pub use rrelayer_core::{
             SendTransactionResult,
         },
         queue_system::ReplaceTransactionResult,
-        types::{Transaction, TransactionData, TransactionId, TransactionSpeed, TransactionValue},
+        types::{
+            Transaction, TransactionBlob, TransactionConversionError, TransactionData,
+            TransactionHash, TransactionId, TransactionNonce, TransactionSpeed, TransactionStatus,
+            TransactionValue,
+        },
     },
 };

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+fix: Expose all Transaction-related types to the rust sdk
+
 ---
 
 ### Breaking changes


### PR DESCRIPTION
Exports some useful types like TransactionHash, TransactionStatus and a few more to the Rust SDK. 