### PR TITLE
relayer nonce reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,6 @@ on:
       - 'release/**'
       - 'master'
   pull_request:
-    branches:
-      - 'master'
-      - '**'
-    types: [opened, synchronize, reopened]
 
 jobs:
   fmt:
@@ -20,10 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      # Toolchain file bug workaround: https://github.com/dtolnay/rust-toolchain/issues/153
       - run: rustup component add rustfmt
-      - name: Run Fmt Check
-        run: cargo fmt --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -33,226 +27,30 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: rustup component add clippy
-      - name: Run clippy
-        run: cargo clippy -- -D warnings -A clippy::uninlined_format_args
+      - run: cargo clippy -- -D warnings -A clippy::uninlined_format_args
 
-  build:
-    if: |
-      (github.event_name == 'push' || github.event_name == 'pull_request') &&
-      github.actor != 'github-actions[bot]' &&
-      (
-        !(github.event_name == 'pull_request' &&
-          startsWith(github.event.pull_request.head.ref, 'release/') &&
-          github.event.pull_request.base.ref == 'master') ||
-        (github.event_name == 'pull_request' &&
-          (contains(github.event.pull_request.head.ref, '/merge') ||
-           startsWith(github.event.pull_request.head.ref, 'merge')))
-      ) &&
-      !(github.ref == 'refs/heads/master' && 
-        github.event_name == 'push' && 
-        (contains(github.event.head_commit.message, 'Release v') || 
-         contains(github.event.head_commit.message, 'release/')))
-    name: ${{ matrix.target }} (${{ matrix.runner }})
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 240
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-            platform: linux
-            arch: amd64
-          - runner: macos-15-intel
-            target: x86_64-apple-darwin
-            platform: darwin
-            arch: amd64
-          - runner: macos-latest
-            target: aarch64-apple-darwin
-            platform: darwin
-            arch: arm64
-          - runner: windows-latest
-            target: x86_64-pc-windows-msvc
-            platform: win32
-            arch: amd64
-
-    env:
-      BUILD_TYPE: release
-
+  test:
+    name: Test
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref_name }}
-
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
           cache-on-failure: true
-
-      - name: Apple M1 setup
-        if: matrix.target == 'aarch64-apple-darwin'
-        run: |
-          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
-
-      - name: Linux ARM setup
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-
-      - name: Install MSVC target
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        run: rustup target add x86_64-pc-windows-msvc
-
-      - name: Install OpenSSL development libraries
-        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'x86_64-unknown-linux-gnu'
+      - name: Install dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev pkg-config
-
-      - name: Setup cross-compilation for pkg-config
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
-          echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-          echo "PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-
-      - name: Extract version name
-        id: extract_version
-        shell: bash
-        run: echo "VERSION_NAME=${GITHUB_REF#refs/heads/release/}" >> $GITHUB_ENV
-
-      - name: Install vcpkg on Windows
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          git clone https://github.com/Microsoft/vcpkg.git C:\vcpkg
-          C:\vcpkg\bootstrap-vcpkg.bat
-          C:\vcpkg\vcpkg integrate install
-          echo "VCPKG_ROOT=C:\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "C:\vcpkg" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install CMake on Windows
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          choco install cmake --version=3.20.0 --installargs 'ADD_CMAKE_TO_PATH=System'
-          refreshenv
-          cmake --version
-          echo "CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Install dependencies with vcpkg on Windows
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          C:\vcpkg\vcpkg install openssl:x64-windows-static-md zlib:x64-windows-static-md
-
-      - name: Build binaries
-        working-directory: crates/cli
-        env:
-          CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
-        shell: bash
-        run: |
-          set -eo pipefail
-          target="${{ matrix.target }}"
-          flags=()
-
-          if [[ "$target" != *msvc* && "$target" != "aarch64-unknown-linux-gnu" ]]; then
-            flags+=(--features jemalloc)
-          fi
-
-          [[ "$target" == *windows* ]] && exe=".exe"
-
-          if [[ "$target" == *windows* ]]; then
-            export PATH="$PATH:/c/vcpkg"
-            echo "CMAKE_TOOLCHAIN_FILE: $CMAKE_TOOLCHAIN_FILE"
-            ls -l "$CMAKE_TOOLCHAIN_FILE" || echo "Toolchain file not found!"
-          fi
-
-          if [[ "${{ env.BUILD_TYPE }}" == "release" ]]; then
-            RUST_BACKTRACE=1 CMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE" cargo build --release --target "$target" "${flags[@]}" -vv
-          else
-            RUST_BACKTRACE=1 CMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE" cargo build --target "$target" "${flags[@]}" -vv
-          fi
-
-      - name: Smoke Test
-        shell: bash
-        run: |
-          set -eo pipefail
-          target="${{ matrix.target }}"
-          build_type="${{ env.BUILD_TYPE }}"
-          binary_path="${{ github.workspace }}/target/$target/$build_type/rrelayer_cli"
-          
-          if [[ "$target" == *windows* ]]; then
-            binary_path+=".exe"
-          fi
-          
-          echo "Running smoke test for $binary_path"
-          "$binary_path" --version
-          "$binary_path" help
-
-      - name: Archive binaries
-        id: artifacts
-        if: startsWith(github.ref, 'refs/heads/release/')
-        env:
-          PLATFORM_NAME: ${{ matrix.platform }}
-          TARGET: ${{ matrix.target }}
-          ARCH: ${{ matrix.arch }}
-          VERSION_NAME: ${{ env.VERSION_NAME }}
-        shell: bash
-        run: |
-          set -eo pipefail
-          BUILD_DIR="${{ github.workspace }}/target/${TARGET}/${{ env.BUILD_TYPE }}"
-          CLI_BINARY_NAME="rrelayer_cli"
-          [[ "$PLATFORM_NAME" == "win32" ]] && CLI_BINARY_NAME="rrelayer_cli.exe"
-          
-          # Create a temporary staging directory for creating the archive
-          STAGING_DIR="staging"
-          mkdir -p "$STAGING_DIR"
-
-          # Copy binaries to the staging directory
-          echo "Copying $BUILD_DIR/$CLI_BINARY_NAME to $STAGING_DIR/"
-          cp "$BUILD_DIR/$CLI_BINARY_NAME" "$STAGING_DIR/"
-          
-          # Create the final archive
-          if [ "$PLATFORM_NAME" == "linux" ] || [ "$PLATFORM_NAME" == "darwin" ]; then
-            FILE_NAME="rrelayer_${PLATFORM_NAME}-${ARCH}.tar.gz"
-            tar -czvf "$FILE_NAME" -C "$STAGING_DIR" .
-          else
-            FILE_NAME="rrelayer_${PLATFORM_NAME}-${ARCH}.zip"
-            (cd "$STAGING_DIR" && 7z a -tzip "${{ github.workspace }}/$FILE_NAME" .)
-          fi
-          
-          echo "Created archive: $FILE_NAME"
-          echo "file_name=$FILE_NAME" >> $GITHUB_OUTPUT
-
       - name: Run tests
-        shell: bash
-        run: |
-          set -eo pipefail
-          target="${{ matrix.target }}"
-          
-          cargo test --exclude rust-sdk-playground --workspace --release --target "$target"
-
-      - name: Upload artifact
-        if: startsWith(github.ref, 'refs/heads/release/')
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.platform }}-${{ matrix.arch }}
-          path: ${{ steps.artifacts.outputs.file_name }}
+        run: cargo test --exclude rust-sdk-playground --workspace
 
   create_pr:
     name: Create Release PR
     runs-on: ubuntu-22.04
-    needs: build
+    needs: test
     if: |
-      github.actor != 'github-actions[bot]' && 
+      github.actor != 'github-actions[bot]' &&
       startsWith(github.ref, 'refs/heads/release/')
     steps:
       - uses: actions/checkout@v4
@@ -261,171 +59,16 @@ jobs:
           fetch-depth: 0
 
       - name: Extract version from branch name
-        shell: bash
         run: |
           VERSION=${GITHUB_REF#refs/heads/release/}
           echo "VERSION_NAME=$VERSION" >> $GITHUB_ENV
 
       - name: Update Cargo.toml versions
-        shell: bash
         run: |
           sed -i 's/^version = ".*"/version = "${{ env.VERSION_NAME }}"/' crates/cli/Cargo.toml
           sed -i 's/^version = ".*"/version = "${{ env.VERSION_NAME }}"/' crates/core/Cargo.toml
           sed -i 's/^version = ".*"/version = "${{ env.VERSION_NAME }}"/' crates/sdk/Cargo.toml
           sed -i 's/^version = ".*"/version = "${{ env.VERSION_NAME }}"/' Cargo.toml
-
-      # Temporarily commented out changelog update for release process
-      # - name: Update Changelog
-      #   shell: bash
-      #   run: |
-      #     CHANGELOG_FILE="documentation/rrelayer/docs/pages/changelog.mdx"
-      #     DAY=$(date '+%d' | sed 's/^0*//')
-      #     MONTH=$(date '+%B')
-      #     YEAR=$(date '+%Y')
-      #     
-      #     # Add ordinal suffix
-      #     case $DAY in
-      #       1|21|31) SUFFIX="st";;
-      #       2|22) SUFFIX="nd";;
-      #       3|23) SUFFIX="rd";;
-      #       *) SUFFIX="th";;
-      #     esac
-      #     
-      #     DATE="$DAY$SUFFIX $MONTH $YEAR"
-      #     
-      #     echo "Updating changelog for version ${{ env.VERSION_NAME }}"
-      #     
-      #     # Create changelog if it doesn't exist
-      #     if [[ ! -f "$CHANGELOG_FILE" ]]; then
-      #       cat > "$CHANGELOG_FILE" << EOF
-      #     # Changelog
-      #     
-      #     ## Changes Not Deployed
-      #     -------------------------------------------------
-      #     
-      #     ### Features
-      #     -------------------------------------------------
-      #     
-      #     ### Bug fixes
-      #     -------------------------------------------------
-      #     
-      #     ### Breaking changes
-      #     -------------------------------------------------
-      #     
-      #     ## Releases
-      #     -------------------------------------------------
-      #     
-      #     all release branches are deployed through \`release/VERSION_NUMBER\` branches
-      #     
-      #     EOF
-      #     fi
-      #     
-      #     # Create a temporary file to work with
-      #     cp "$CHANGELOG_FILE" changelog_temp.md
-      #     
-      #     # Extract just the bug fixes line directly from Changes Not Deployed section
-      #     BUG_FIXES=$(sed -n '/^## Changes Not Deployed/,/^## Releases/p' changelog_temp.md | grep "^- fix:" | head -5)
-      #     
-      #     # Use the simple extraction for now
-      #     FEATURES=""
-      #     BUG_FIXES="$BUG_FIXES"
-      #     BREAKING_CHANGES=""
-      #     
-      #     # Save the extracted content for PR creation
-      #     {
-      #       echo "### Changes in this release:"
-      #       echo "-------------------------------------------------"
-      #       echo "### Features"
-      #       echo "-------------------------------------------------"
-      #       if [[ -n "$FEATURES" ]]; then
-      #         echo "$FEATURES"
-      #       fi
-      #       echo ""
-      #       echo "### Bug fixes"
-      #       echo "-------------------------------------------------"
-      #       if [[ -n "$BUG_FIXES" ]]; then
-      #         echo "$BUG_FIXES"
-      #       fi
-      #       echo ""
-      #       echo "### Breaking changes"
-      #       echo "-------------------------------------------------"
-      #       if [[ -n "$BREAKING_CHANGES" ]]; then
-      #         echo "$BREAKING_CHANGES"
-      #       fi
-      #     } > pr_body_content.txt
-      #     
-      #     # Save to environment variable
-      #     echo "PR_BODY_CONTENT<<EOF" >> $GITHUB_ENV
-      #     cat pr_body_content.txt >> $GITHUB_ENV
-      #     echo "EOF" >> $GITHUB_ENV
-      #     
-      #     # Create new release entry
-      #     cat > new_release.txt << EOF
-      #     # ${{ env.VERSION_NAME }}-beta - $DATE
-      #     
-      #     github branch - https://github.com/joshstevens19/rrelayer/tree/release/${{ env.VERSION_NAME }}
-      #     
-      #     - linux binary - https://github.com/joshstevens19/rrelayer/releases/download/v${{ env.VERSION_NAME }}/rrelayer_linux-amd64.tar.gz
-      #     - mac apple silicon binary - https://github.com/joshstevens19/rrelayer/releases/download/v${{ env.VERSION_NAME }}/rrelayer_darwin-arm64.tar.gz
-      #     - mac apple intel binary - https://github.com/joshstevens19/rrelayer/releases/download/v${{ env.VERSION_NAME }}/rrelayer_darwin-amd64.tar.gz
-      #     - windows binary - https://github.com/joshstevens19/rrelayer/releases/download/v${{ env.VERSION_NAME }}/rrelayer_win32-amd64.zip
-      #     EOF
-      #     
-      #     # Add sections if they have content
-      #     if [[ -n "$FEATURES" && "$FEATURES" =~ [^[:space:]] ]]; then
-      #       echo "" >> new_release.txt
-      #       echo "### Features" >> new_release.txt
-      #       echo "-------------------------------------------------" >> new_release.txt
-      #       echo "$FEATURES" >> new_release.txt
-      #     fi
-      #     
-      #     if [[ -n "$BUG_FIXES" && "$BUG_FIXES" =~ [^[:space:]] ]]; then
-      #       echo "" >> new_release.txt
-      #       echo "### Bug fixes" >> new_release.txt
-      #       echo "-------------------------------------------------" >> new_release.txt
-      #       echo "$BUG_FIXES" >> new_release.txt
-      #     fi
-      #     
-      #     if [[ -n "$BREAKING_CHANGES" && "$BREAKING_CHANGES" =~ [^[:space:]] ]]; then
-      #       echo "" >> new_release.txt
-      #       echo "### Breaking changes" >> new_release.txt
-      #       echo "-------------------------------------------------" >> new_release.txt
-      #       echo "$BREAKING_CHANGES" >> new_release.txt
-      #     fi
-      #     
-      #     # Get existing releases (everything after "## Releases")
-      #     EXISTING_RELEASES=$(awk '/^## Releases/,0' changelog_temp.md | tail -n +5)
-      #     
-      #     # Create new changelog
-      #     cat > "$CHANGELOG_FILE" << EOF
-      #     # Changelog
-      #     
-      #     ## Changes Not Deployed
-      #     -------------------------------------------------
-      #     
-      #     ### Features
-      #     -------------------------------------------------
-      #     
-      #     ### Bug fixes
-      #     -------------------------------------------------
-      #     
-      #     ### Breaking changes
-      #     -------------------------------------------------
-      #     
-      #     ## Releases
-      #     -------------------------------------------------
-      #     
-      #     all release branches are deployed through \`release/VERSION_NUMBER\` branches
-      #     
-      #     $(cat new_release.txt)
-      #     
-      #     $EXISTING_RELEASES
-      #     EOF
-      #     
-      #     # Clean up temporary files
-      #     rm -f changelog_temp.md new_release.txt pr_body_content.txt
-      #     
-      #     echo "Changelog updated successfully"
 
       - name: Commit changes
         run: |
@@ -443,10 +86,8 @@ jobs:
           PR_EXISTS=$(gh pr list --base master --head release/${{ env.VERSION_NAME }} --json number --jq length)
           if [ "$PR_EXISTS" -gt 0 ]; then
             echo "pr_exists=true" >> $GITHUB_OUTPUT
-            echo "PR already exists, skipping creation"
           else
             echo "pr_exists=false" >> $GITHUB_OUTPUT
-            echo "No PR exists, will create one"
           fi
 
       - name: Create Pull Request
@@ -459,334 +100,43 @@ jobs:
             --body "## Release v${{ env.VERSION_NAME }}
 
           This PR contains:
-          - ✅ Version bump to ${{ env.VERSION_NAME }}
-          - ✅ Changelog updated with release notes
-          - ✅ Ready for release
+          - Version bump to ${{ env.VERSION_NAME }}
 
-          **Merging this PR will automatically create a GitHub Release with binaries.**
-
-          ${{ env.PR_BODY_CONTENT }}" \
+          **Merging this PR will automatically create a GitHub Release and build Docker images.**" \
             --base master \
             --head release/${{ env.VERSION_NAME }}
-
-  release_build:
-    name: Build Release Binaries
-    runs-on: ${{ matrix.runner }}
-    if: |
-      github.actor != 'github-actions[bot]' && 
-      github.ref == 'refs/heads/master' && 
-      github.event_name == 'push'
-    timeout-minutes: 240
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-            platform: linux
-            arch: amd64
-          - runner: macos-15-intel
-            target: x86_64-apple-darwin
-            platform: darwin
-            arch: amd64
-          - runner: macos-latest
-            target: aarch64-apple-darwin
-            platform: darwin
-            arch: arm64
-          - runner: windows-latest
-            target: x86_64-pc-windows-msvc
-            platform: win32
-            arch: amd64
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check if this is a release commit and extract version
-        id: check_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          echo "=== DEBUG: Checking recent commits ==="
-          git log --oneline -10 --pretty=format:"%H %s"
-          echo ""
-          echo "=== DEBUG: Checking for release pattern ==="
-          
-          # Check the most recent commit (HEAD) for release pattern
-          RECENT_COMMIT_MSG=$(git log --oneline -1 --pretty=format:"%s")
-          echo "Most recent commit: '$RECENT_COMMIT_MSG'"
-          
-          # Try to extract version from Release v pattern (including PR number)
-          VERSION_FROM_RELEASE=$(echo "$RECENT_COMMIT_MSG" | grep -o 'Release v[0-9]*\.[0-9]*\.[0-9]*' | sed 's/Release v//' || echo "")
-          echo "VERSION_FROM_RELEASE: '$VERSION_FROM_RELEASE'"
-          
-          if [[ -n "$VERSION_FROM_RELEASE" ]]; then
-            echo "VERSION_NAME=$VERSION_FROM_RELEASE" >> $GITHUB_ENV
-            echo "is_release=true" >> $GITHUB_OUTPUT
-            echo "Found release from commit title: Release v$VERSION_FROM_RELEASE"
-          else
-            echo "Not a release commit"
-            echo "is_release=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Skip if not a release
-        if: steps.check_release.outputs.is_release != 'true'
-        run: |
-          echo "Skipping release build - not a release commit"
-          exit 0
-
-      - name: Checkout release branch
-        if: steps.check_release.outputs.is_release == 'true'
-        uses: actions/checkout@v4
-        with:
-          ref: release/${{ env.VERSION_NAME }}
-          fetch-depth: 0
-
-      - uses: dtolnay/rust-toolchain@stable
-        if: steps.check_release.outputs.is_release == 'true'
-        with:
-          targets: ${{ matrix.target }}
-
-      - uses: Swatinem/rust-cache@v2
-        if: steps.check_release.outputs.is_release == 'true'
-        with:
-          key: ${{ matrix.target }}
-          cache-on-failure: true
-
-      - name: Apple M1 setup
-        if: steps.check_release.outputs.is_release == 'true' && matrix.target == 'aarch64-apple-darwin'
-        run: |
-          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
-
-      - name: Install MSVC target
-        if: steps.check_release.outputs.is_release == 'true' && matrix.target == 'x86_64-pc-windows-msvc'
-        run: rustup target add x86_64-pc-windows-msvc
-
-      - name: Install OpenSSL development libraries
-        if: steps.check_release.outputs.is_release == 'true' && matrix.target == 'x86_64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libssl-dev pkg-config
-
-      - name: Install vcpkg on Windows
-        if: steps.check_release.outputs.is_release == 'true' && matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          git clone https://github.com/Microsoft/vcpkg.git C:\vcpkg
-          C:\vcpkg\bootstrap-vcpkg.bat
-          C:\vcpkg\vcpkg integrate install
-          echo "VCPKG_ROOT=C:\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "C:\vcpkg" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install CMake on Windows
-        if: steps.check_release.outputs.is_release == 'true' && matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          choco install cmake --version=3.20.0 --installargs 'ADD_CMAKE_TO_PATH=System'
-          refreshenv
-          cmake --version
-          echo "CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Install dependencies with vcpkg on Windows
-        if: steps.check_release.outputs.is_release == 'true' && matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          C:\vcpkg\vcpkg install openssl:x64-windows-static-md zlib:x64-windows-static-md
-
-      - name: Build binaries
-        if: steps.check_release.outputs.is_release == 'true'
-        working-directory: crates/cli
-        env:
-          CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
-        shell: bash
-        run: |
-          set -eo pipefail
-          target="${{ matrix.target }}"
-          
-          if [[ "$target" != *msvc* && "$target" != "aarch64-unknown-linux-gnu" ]]; then
-            flags+=(--features jemalloc)
-          fi
-
-          if [[ "$target" == *windows* ]]; then
-            export PATH="$PATH:/c/vcpkg"
-            echo "CMAKE_TOOLCHAIN_FILE: $CMAKE_TOOLCHAIN_FILE"
-            ls -l "$CMAKE_TOOLCHAIN_FILE" || echo "Toolchain file not found!"
-          fi
-
-          RUST_BACKTRACE=1 CMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE" cargo build --release --target "$target" -vv
-
-      - name: Smoke Test
-        if: steps.check_release.outputs.is_release == 'true'
-        shell: bash
-        run: |
-          set -eo pipefail
-          target="${{ matrix.target }}"
-          binary_path="${{ github.workspace }}/target/$target/release/rrelayer_cli"
-          
-          if [[ "$target" == *windows* ]]; then
-            binary_path+=".exe"
-          fi
-          
-          echo "Running smoke test for $binary_path"
-          "$binary_path" --version
-          "$binary_path" help
-
-      - name: Archive binaries
-        if: steps.check_release.outputs.is_release == 'true'
-        id: artifacts
-        env:
-          PLATFORM_NAME: ${{ matrix.platform }}
-          TARGET: ${{ matrix.target }}
-          ARCH: ${{ matrix.arch }}
-          VERSION_NAME: ${{ env.VERSION_NAME }}
-        shell: bash
-        run: |
-          set -eo pipefail
-          BUILD_DIR="${{ github.workspace }}/target/${TARGET}/release"
-          CLI_BINARY_NAME="rrelayer_cli"
-          [[ "$PLATFORM_NAME" == "win32" ]] && CLI_BINARY_NAME="rrelayer_cli.exe"
-          
-          # Create a temporary staging directory for creating the archive
-          STAGING_DIR="staging"
-          mkdir -p "$STAGING_DIR"
-
-          # Copy binaries to the staging directory
-          echo "Copying $BUILD_DIR/$CLI_BINARY_NAME to $STAGING_DIR/"
-          cp "$BUILD_DIR/$CLI_BINARY_NAME" "$STAGING_DIR/"
-          
-          # Create the final archive
-          if [ "$PLATFORM_NAME" == "linux" ] || [ "$PLATFORM_NAME" == "darwin" ]; then
-            FILE_NAME="rrelayer_${PLATFORM_NAME}-${ARCH}.tar.gz"
-            tar -czvf "$FILE_NAME" -C "$STAGING_DIR" .
-          else
-            FILE_NAME="rrelayer_${PLATFORM_NAME}-${ARCH}.zip"
-            (cd "$STAGING_DIR" && 7z a -tzip "${{ github.workspace }}/$FILE_NAME" .)
-          fi
-          
-          echo "Created archive: $FILE_NAME"
-          echo "file_name=$FILE_NAME" >> $GITHUB_OUTPUT
-
-      - name: Upload artifact
-        if: steps.check_release.outputs.is_release == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-${{ matrix.platform }}-${{ matrix.arch }}
-          path: ${{ steps.artifacts.outputs.file_name }}
 
   release:
     name: Create GitHub Release
     runs-on: ubuntu-22.04
-    needs: release_build
-    if: |
-      github.actor != 'github-actions[bot]' && 
-      github.ref == 'refs/heads/master' && 
-      github.event_name == 'push'
-    outputs:
-      version: ${{ steps.check_release.outputs.version }}
-      is_release: ${{ steps.check_release.outputs.is_release }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check if this is a release commit and extract version
-        id: check_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          echo "=== DEBUG: Checking recent commits ==="
-          git log --oneline -10 --pretty=format:"%H %s"
-          echo ""
-          echo "=== DEBUG: Checking for release pattern ==="
-          
-          # Check the most recent commit (HEAD) for release pattern
-          RECENT_COMMIT_MSG=$(git log --oneline -1 --pretty=format:"%s")
-          echo "Most recent commit: '$RECENT_COMMIT_MSG'"
-          
-          # Try to extract version from Release v pattern (including PR number)
-          VERSION_FROM_RELEASE=$(echo "$RECENT_COMMIT_MSG" | grep -o 'Release v[0-9]*\.[0-9]*\.[0-9]*' | sed 's/Release v//' || echo "")
-          echo "VERSION_FROM_RELEASE: '$VERSION_FROM_RELEASE'"
-          
-          if [[ -n "$VERSION_FROM_RELEASE" ]]; then
-            echo "VERSION_NAME=$VERSION_FROM_RELEASE" >> $GITHUB_ENV
-            echo "is_release=true" >> $GITHUB_OUTPUT
-            echo "version=$VERSION_FROM_RELEASE" >> $GITHUB_OUTPUT
-            echo "Found release from commit title: Release v$VERSION_FROM_RELEASE"
-          else
-            echo "Not a release commit"
-            echo "is_release=false" >> $GITHUB_OUTPUT
-            echo "version=" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Skip if not a release
-        if: steps.check_release.outputs.is_release != 'true'
-        run: |
-          echo "Skipping release creation - not a release commit"
-          exit 0
-
-      - name: Download release artifacts
-        if: steps.check_release.outputs.is_release == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          path: ./release-artifacts
-
-      - name: Display structure of downloaded files
-        if: steps.check_release.outputs.is_release == 'true'
-        run: ls -la ./release-artifacts/
-
-      - name: Create GitHub Release
-        if: steps.check_release.outputs.is_release == 'true'
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ env.VERSION_NAME }}
-          release_name: Release v${{ env.VERSION_NAME }}
-          draft: false
-          prerelease: false
-          body: |
-            Release v${{ env.VERSION_NAME }}
-            
-            ## Installation
-            ```bash
-            # Latest version
-            curl -sSfL https://docs.rrelayer.com/install.sh | bash
-            
-            # Specific version  
-            curl -sSfL https://docs.rrelayer.com/install.sh | bash -s -- --version ${{ env.VERSION_NAME }}
-            ```
-        continue-on-error: true
-
-      - name: Upload Release Assets
-        if: steps.check_release.outputs.is_release == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          for platform_dir in ./release-artifacts/*/; do
-            for file in "$platform_dir"*; do
-              if [[ -f "$file" ]]; then
-                filename=$(basename "$file")
-                echo "Uploading $filename"
-                gh release upload v${{ env.VERSION_NAME }} "$file" --clobber
-              fi
-            done
-          done
-
-  docker:
-    name: Build and Publish Docker Image
-    needs: release
+    needs: [fmt, clippy, test]
     if: |
       github.actor != 'github-actions[bot]' &&
       github.ref == 'refs/heads/master' &&
       github.event_name == 'push'
-    uses: ./.github/workflows/docker.yml
-    with:
-      version: ${{ needs.release.outputs.version }}
-    secrets: inherit
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if this is a release commit
+        id: check_release
+        run: |
+          COMMIT_MSG=$(git log --oneline -1 --pretty=format:"%s")
+          VERSION=$(echo "$COMMIT_MSG" | grep -o 'Release v[0-9]*\.[0-9]*\.[0-9]*' | sed 's/Release v//' || echo "")
+          if [[ -n "$VERSION" ]]; then
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.is_release == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.check_release.outputs.version }}"
+          gh release create "v${VERSION}" \
+            --title "Release v${VERSION}" \
+            --generate-notes

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,13 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., 1.2.3) - leave empty for master build'
-        required: false
-        type: string
-  workflow_call:
-    inputs:
-      version:
-        description: 'Release version (e.g., 1.2.3)'
+        description: 'Release version (e.g., 1.2.3) - leave empty for edge build'
         required: false
         type: string
   release:
@@ -28,19 +22,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Create docker-binary directory
-        run: mkdir -p docker-binary
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
         with:
           key: x86_64-unknown-linux-gnu-docker
 
@@ -53,8 +41,7 @@ jobs:
         working-directory: crates/cli
         env:
           RUSTFLAGS: '-C target-cpu=x86-64-v2'
-        run: |
-          cargo build --release --target x86_64-unknown-linux-gnu --features jemalloc
+        run: cargo build --release --target x86_64-unknown-linux-gnu --features jemalloc
 
       - name: Prepare binary for Docker
         run: |
@@ -62,23 +49,22 @@ jobs:
           cp target/x86_64-unknown-linux-gnu/release/rrelayer_cli docker-binary/rrelayer_cli
           chmod +x docker-binary/rrelayer_cli
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: Log into registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate SHA-based internal tag
+      - name: Generate tag
         id: tags
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           echo "tag=${{ env.IMAGE }}:sha-${SHORT_SHA}-amd64" >> $GITHUB_OUTPUT
 
-      - name: Build and push AMD64 Docker image
+      - name: Build and push AMD64 image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -88,8 +74,8 @@ jobs:
           platforms: linux/amd64
           provenance: mode=max
           sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-amd64
+          cache-to: type=gha,mode=max,scope=docker-amd64
 
   build-arm64:
     name: Build ARM64 Docker Image
@@ -98,19 +84,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Create docker-binary directory
-        run: mkdir -p docker-binary
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-unknown-linux-gnu
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
         with:
           key: aarch64-unknown-linux-gnu-docker
 
@@ -123,8 +103,7 @@ jobs:
         working-directory: crates/cli
         env:
           RUSTFLAGS: '-C target-cpu=neoverse-n1'
-        run: |
-          cargo build --release --target aarch64-unknown-linux-gnu
+        run: cargo build --release --target aarch64-unknown-linux-gnu
 
       - name: Prepare binary for Docker
         run: |
@@ -132,23 +111,22 @@ jobs:
           cp target/aarch64-unknown-linux-gnu/release/rrelayer_cli docker-binary/rrelayer_cli
           chmod +x docker-binary/rrelayer_cli
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: Log into registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate SHA-based internal tag
+      - name: Generate tag
         id: tags
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           echo "tag=${{ env.IMAGE }}:sha-${SHORT_SHA}-arm64" >> $GITHUB_OUTPUT
 
-      - name: Build and push ARM64 Docker image
+      - name: Build and push ARM64 image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -158,8 +136,8 @@ jobs:
           platforms: linux/arm64
           provenance: mode=max
           sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-arm64
+          cache-to: type=gha,mode=max,scope=docker-arm64
 
   create-manifest:
     name: Create Multi-Arch Manifest
@@ -169,49 +147,37 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: Log into registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
+          elif [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create and push multi-arch manifest
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          AMD64_IMAGE="${{ env.IMAGE }}:sha-${SHORT_SHA}-amd64"
-          ARM64_IMAGE="${{ env.IMAGE }}:sha-${SHORT_SHA}-arm64"
-          
-          echo "Source images:"
-          echo "  AMD64: $AMD64_IMAGE"
-          echo "  ARM64: $ARM64_IMAGE"
-          
-          VERSION="${{ inputs.version }}"
-          
+          AMD64="${{ env.IMAGE }}:sha-${SHORT_SHA}-amd64"
+          ARM64="${{ env.IMAGE }}:sha-${SHORT_SHA}-arm64"
+          VERSION="${{ steps.version.outputs.version }}"
+
           if [ -n "$VERSION" ]; then
-            # Release build: create version tag and latest tag
-            echo "Creating release manifests for version: $VERSION"
-            
-            # Version tag (e.g., 1.2.3)
-            echo "Creating manifest for tag: $VERSION"
-            docker buildx imagetools create -t "${{ env.IMAGE }}:$VERSION" \
-              "$AMD64_IMAGE" \
-              "$ARM64_IMAGE"
-            
-            # Latest tag
-            echo "Creating manifest for tag: latest"
-            docker buildx imagetools create -t "${{ env.IMAGE }}:latest" \
-              "$AMD64_IMAGE" \
-              "$ARM64_IMAGE"
+            docker buildx imagetools create -t "${{ env.IMAGE }}:${VERSION}" "$AMD64" "$ARM64"
+            docker buildx imagetools create -t "${{ env.IMAGE }}:latest" "$AMD64" "$ARM64"
           else
-            # Non-release build (master): create master tag only
-            echo "Creating master manifest"
-            docker buildx imagetools create -t "${{ env.IMAGE }}:master" \
-              "$AMD64_IMAGE" \
-              "$ARM64_IMAGE"
+            docker buildx imagetools create -t "${{ env.IMAGE }}:edge" "$AMD64" "$ARM64"
           fi
-          
-          echo "Manifests created successfully"

--- a/crates/core/src/postgres.rs
+++ b/crates/core/src/postgres.rs
@@ -10,7 +10,8 @@ use postgres_native_tls::MakeTlsConnector;
 use tokio::{task, time::timeout};
 pub use tokio_postgres::types::{ToSql, Type as PgType};
 use tokio_postgres::{
-    config::SslMode, Config, CopyInSink, Error as PgError, Row, Statement, ToStatement,
+    config::SslMode, error::SqlState, Config, CopyInSink, Error as PgError, Row, Statement,
+    ToStatement,
 };
 
 pub fn connection_string() -> Result<String, env::VarError> {
@@ -47,6 +48,18 @@ pub enum PostgresError {
 
     #[error("Connection pool error: {0}")]
     ConnectionPoolError(#[from] RunError<tokio_postgres::Error>),
+}
+
+impl PostgresError {
+    pub fn is_unique_violation_on(&self, constraint: &str) -> bool {
+        match self {
+            PostgresError::PgError(error) => error.as_db_error().is_some_and(|db_error| {
+                db_error.code() == &SqlState::UNIQUE_VIOLATION
+                    && db_error.constraint() == Some(constraint)
+            }),
+            PostgresError::ConnectionPoolError(_) => false,
+        }
+    }
 }
 
 pub struct PostgresClient {

--- a/crates/core/src/schema/mod.rs
+++ b/crates/core/src/schema/mod.rs
@@ -1,5 +1,6 @@
 use crate::schema::v1_0_1::apply_v1_0_1_schema;
 use crate::schema::v1_0_2::apply_v1_0_2_schema;
+use crate::schema::v1_0_3::apply_v1_0_3_schema;
 use crate::{
     postgres::{PostgresClient, PostgresError},
     schema::v1_0_0::apply_v1_0_0_schema,
@@ -8,12 +9,16 @@ use crate::{
 mod v1_0_0;
 mod v1_0_1;
 mod v1_0_2;
+mod v1_0_3;
+
+pub use v1_0_3::TRANSACTION_EXTERNAL_ID_UNIQUE_INDEX;
 
 /// Applies the database schema to the database.
 pub async fn apply_schema(client: &PostgresClient) -> Result<(), PostgresError> {
     apply_v1_0_0_schema(client).await?;
     apply_v1_0_1_schema(client).await?;
     apply_v1_0_2_schema(client).await?;
+    apply_v1_0_3_schema(client).await?;
 
     Ok(())
 }

--- a/crates/core/src/schema/v1_0_3.rs
+++ b/crates/core/src/schema/v1_0_3.rs
@@ -1,0 +1,18 @@
+use crate::postgres::{PostgresClient, PostgresError};
+
+pub const TRANSACTION_EXTERNAL_ID_UNIQUE_INDEX: &str = "idx_transaction_relayer_external_id_unique";
+
+/// Applies the RRelayer database schema version 1.0.3.
+/// Adds per-relayer idempotency for non-null transaction external IDs.
+pub async fn apply_v1_0_3_schema(client: &PostgresClient) -> Result<(), PostgresError> {
+    let schema_sql = format!(
+        r#"
+        CREATE UNIQUE INDEX IF NOT EXISTS {TRANSACTION_EXTERNAL_ID_UNIQUE_INDEX}
+        ON relayer.transaction(relayer_id, external_id)
+        WHERE external_id IS NOT NULL;
+    "#
+    );
+
+    client.batch_execute(&schema_sql).await?;
+    Ok(())
+}

--- a/crates/core/src/transaction/db/read.rs
+++ b/crates/core/src/transaction/db/read.rs
@@ -124,4 +124,27 @@ impl PostgresClient {
             Some(row) => Ok(Some(build_transaction_from_transaction_view(&row))),
         }
     }
+
+    pub async fn get_transaction_by_relayer_and_external_id(
+        &self,
+        relayer_id: &RelayerId,
+        external_id: &str,
+    ) -> Result<Option<Transaction>, PostgresError> {
+        let row = self
+            .query_one_or_none(
+                "
+                    SELECT *
+                    FROM relayer.transaction
+                    WHERE relayer_id = $1
+                    AND external_id = $2;
+                ",
+                &[relayer_id, &external_id],
+            )
+            .await?;
+
+        match row {
+            None => Ok(None),
+            Some(row) => Ok(Some(build_transaction_from_transaction_view(&row))),
+        }
+    }
 }

--- a/crates/core/src/transaction/db/write.rs
+++ b/crates/core/src/transaction/db/write.rs
@@ -168,7 +168,7 @@ impl PostgresClient {
                     &transaction.value,
                     &transaction.blobs,
                     &transaction.speed,
-                    &transaction.status,
+                    &TransactionStatus::FAILED,
                     &transaction.expires_at,
                     &transaction.queued_at,
                     &failed_reason.chars().take(2000).collect::<String>(),

--- a/crates/core/src/transaction/nonce_manager.rs
+++ b/crates/core/src/transaction/nonce_manager.rs
@@ -1,21 +1,32 @@
-use tokio::sync::Mutex;
+use std::sync::Arc;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
 use crate::transaction::types::TransactionNonce;
 
 pub struct NonceManager {
-    nonce: Mutex<TransactionNonce>,
+    nonce: Arc<Mutex<TransactionNonce>>,
+}
+
+pub struct NonceReservation {
+    nonce: TransactionNonce,
+    committed: bool,
+    guard: Option<OwnedMutexGuard<TransactionNonce>>,
 }
 
 impl NonceManager {
     pub fn new(current_nonce: TransactionNonce) -> Self {
-        NonceManager { nonce: Mutex::new(current_nonce) }
+        NonceManager { nonce: Arc::new(Mutex::new(current_nonce)) }
     }
 
-    pub async fn get_and_increment(&self) -> TransactionNonce {
-        let mut nonce_guard = self.nonce.lock().await;
+    /// Reserves and increments the next nonce while holding the internal mutex until commit or drop.
+    ///
+    /// Callers should keep the work between reservation and `NonceReservation::commit` short; if
+    /// the reservation is dropped before commit, the nonce cursor is rolled back automatically.
+    pub async fn reserve_next(&self) -> NonceReservation {
+        let mut nonce_guard = self.nonce.clone().lock_owned().await;
         let current_nonce = *nonce_guard;
         *nonce_guard = current_nonce + 1;
-        current_nonce
+        NonceReservation { nonce: current_nonce, committed: false, guard: Some(nonce_guard) }
     }
 
     pub async fn sync_with_onchain_nonce(&self, onchain_nonce: TransactionNonce) {
@@ -28,5 +39,57 @@ impl NonceManager {
     pub async fn get_current_nonce(&self) -> TransactionNonce {
         let nonce_guard = self.nonce.lock().await;
         *nonce_guard
+    }
+}
+
+impl NonceReservation {
+    pub fn nonce(&self) -> TransactionNonce {
+        self.nonce
+    }
+
+    pub fn commit(mut self) {
+        self.committed = true;
+        self.guard.take();
+    }
+}
+
+impl Drop for NonceReservation {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+
+        if let Some(mut nonce_guard) = self.guard.take() {
+            *nonce_guard = self.nonce;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NonceManager;
+    use crate::transaction::types::TransactionNonce;
+
+    #[tokio::test]
+    async fn reservation_rolls_back_when_dropped() {
+        let manager = NonceManager::new(TransactionNonce::new(7));
+
+        {
+            let reservation = manager.reserve_next().await;
+            assert_eq!(reservation.nonce(), TransactionNonce::new(7));
+        }
+
+        assert_eq!(manager.get_current_nonce().await, TransactionNonce::new(7));
+    }
+
+    #[tokio::test]
+    async fn reservation_commit_keeps_increment() {
+        let manager = NonceManager::new(TransactionNonce::new(7));
+
+        let reservation = manager.reserve_next().await;
+        assert_eq!(reservation.nonce(), TransactionNonce::new(7));
+        reservation.commit();
+
+        assert_eq!(manager.get_current_nonce().await, TransactionNonce::new(8));
     }
 }

--- a/crates/core/src/transaction/queue_system/transactions_queues.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queues.rs
@@ -26,19 +26,20 @@ use super::{
     transactions_queue::TransactionsQueue,
     types::{
         AddTransactionError, CancelTransactionError, CancelTransactionResult, CompetitionType,
-        EditableTransactionType, ProcessInmempoolStatus, ProcessInmempoolTransactionError,
-        ProcessMinedStatus, ProcessMinedTransactionError, ProcessPendingStatus,
-        ProcessPendingTransactionError, ProcessResult, ReplaceTransactionError,
-        ReplaceTransactionResult, TransactionRelayerSetup, TransactionToSend,
-        TransactionsQueueSetup,
+        CompetitiveTransaction, EditableTransactionType, ProcessInmempoolStatus,
+        ProcessInmempoolTransactionError, ProcessMinedStatus, ProcessMinedTransactionError,
+        ProcessPendingStatus, ProcessPendingTransactionError, ProcessResult,
+        ReplaceTransactionError, ReplaceTransactionResult, TransactionRelayerSetup,
+        TransactionToSend, TransactionsQueueSetup,
     },
 };
+use crate::schema::TRANSACTION_EXTERNAL_ID_UNIQUE_INDEX;
 use crate::transaction::api::RelayTransactionRequest;
 use crate::transaction::queue_system::types::SendTransactionGasPriceError;
 use crate::transaction::types::{TransactionBlob, TransactionConversionError, TransactionSpeed};
 use crate::{
     gas::{BlobGasOracleCache, BlobGasPriceResult, GasLimit, GasOracleCache, GasPriceResult},
-    postgres::{PostgresClient, PostgresConnectionError},
+    postgres::{PostgresClient, PostgresConnectionError, PostgresError},
     relayer::RelayerId,
     safe_proxy::SafeProxyManager,
     shared::{cache::Cache, common_types::WalletOrProviderError},
@@ -47,7 +48,10 @@ use crate::{
         cache::invalidate_transaction_no_state_cache,
         nonce_manager::NonceManager,
         queue_system::types::TransactionQueueSendTransactionError,
-        types::{Transaction, TransactionData, TransactionId, TransactionStatus, TransactionValue},
+        types::{
+            Transaction, TransactionData, TransactionId, TransactionNonce, TransactionStatus,
+            TransactionValue,
+        },
     },
     webhooks::WebhookManager,
 };
@@ -80,11 +84,26 @@ impl TransactionsQueues {
         let mut relayer_block_times_ms = HashMap::new();
 
         for setup in setups {
-            let current_nonce = setup.evm_provider.get_nonce(&setup.relayer).await?;
+            let onchain_nonce = setup.evm_provider.get_nonce(&setup.relayer).await?;
+            // read the nonces assigned to in-flight transactions to determine the next nonce to use.
+            let open_local_nonce = Self::next_nonce_after_open_transactions(
+                &setup.pending_transactions,
+                &setup.inmempool_transactions,
+                &setup.mined_transactions,
+            );
+            let current_nonce = open_local_nonce
+                .filter(|local_nonce| local_nonce.into_inner() > onchain_nonce.into_inner())
+                .unwrap_or(onchain_nonce);
 
             info!(
-                "Startup nonce synchronization for relayer {} ({}): synchronizing nonce manager with on-chain nonce {}",
-                setup.relayer.name, setup.relayer.id, current_nonce.into_inner()
+                "Startup nonce synchronization for relayer {} ({}): on-chain nonce {}, open local next nonce {}, using {}",
+                setup.relayer.name,
+                setup.relayer.id,
+                onchain_nonce.into_inner(),
+                open_local_nonce
+                    .map(|nonce| nonce.into_inner().to_string())
+                    .unwrap_or_else(|| "none".to_string()),
+                current_nonce.into_inner()
             );
 
             relayer_block_times_ms.insert(setup.relayer.id, setup.evm_provider.blocks_every);
@@ -207,9 +226,210 @@ impl TransactionsQueues {
         Utc::now() + chrono::Duration::hours(12)
     }
 
+    fn next_nonce_after_open_transactions(
+        pending_transactions: &VecDeque<Transaction>,
+        inmempool_transactions: &VecDeque<CompetitiveTransaction>,
+        mined_transactions: &HashMap<TransactionId, Transaction>,
+    ) -> Option<TransactionNonce> {
+        fn nonce_if_open(transaction: &Transaction) -> Option<TransactionNonce> {
+            match transaction.status {
+                TransactionStatus::PENDING
+                | TransactionStatus::INMEMPOOL
+                | TransactionStatus::MINED => Some(transaction.nonce),
+                TransactionStatus::CONFIRMED
+                | TransactionStatus::FAILED
+                | TransactionStatus::EXPIRED
+                | TransactionStatus::CANCELLED
+                | TransactionStatus::DROPPED
+                | TransactionStatus::REPLACED => None,
+            }
+        }
+
+        let pending_nonces = pending_transactions.iter().filter_map(nonce_if_open);
+        let inmempool_nonces = inmempool_transactions.iter().flat_map(|transaction| {
+            nonce_if_open(&transaction.original).into_iter().chain(
+                transaction
+                    .competitive
+                    .as_ref()
+                    .and_then(|(transaction, _)| nonce_if_open(transaction)),
+            )
+        });
+        let mined_nonces = mined_transactions.values().filter_map(nonce_if_open);
+
+        pending_nonces
+            .chain(inmempool_nonces)
+            .chain(mined_nonces)
+            .map(|nonce| nonce.into_inner())
+            .max()
+            .map(|nonce| TransactionNonce::new(nonce + 1))
+    }
+
     /// Checks if a transaction has expired.
     fn has_expired(&self, transaction: &Transaction) -> bool {
         transaction.expires_at < Utc::now()
+    }
+
+    fn transaction_matches_payload(
+        transaction: &Transaction,
+        relayer_id: &RelayerId,
+        transaction_to_send: &TransactionToSend,
+    ) -> bool {
+        transaction.relayer_id == *relayer_id
+            && transaction.to == transaction_to_send.to
+            && transaction.value == transaction_to_send.value
+            && transaction.data == transaction_to_send.data
+            && transaction.speed == transaction_to_send.speed
+            && transaction.blobs == transaction_to_send.blobs
+            && transaction.external_id == transaction_to_send.external_id
+    }
+
+    /// Replays a prior idempotent result once the payload matches; status is intentionally ignored after a hash exists.
+    fn resolve_idempotent_transaction(
+        transaction: Transaction,
+        relayer_id: &RelayerId,
+        transaction_to_send: &TransactionToSend,
+        external_id: &str,
+    ) -> Result<Transaction, AddTransactionError> {
+        if !Self::transaction_matches_payload(&transaction, relayer_id, transaction_to_send) {
+            return Err(AddTransactionError::ExternalIdPayloadMismatch {
+                relayer_id: *relayer_id,
+                external_id: external_id.to_string(),
+            });
+        }
+
+        if transaction.known_transaction_hash.is_some() {
+            return Ok(transaction);
+        }
+
+        Err(AddTransactionError::IdempotentTransactionFailed {
+            relayer_id: *relayer_id,
+            external_id: external_id.to_string(),
+        })
+    }
+
+    /// Loads an existing transaction for a relayer-scoped external id.
+    async fn load_idempotent_transaction(
+        &self,
+        relayer_id: &RelayerId,
+        external_id: &str,
+    ) -> Result<Option<Transaction>, AddTransactionError> {
+        self.db
+            .get_transaction_by_relayer_and_external_id(relayer_id, external_id)
+            .await
+            .map_err(AddTransactionError::CouldNotReadTransactionDb)
+    }
+
+    /// Checks whether a relayer-scoped external id is already assigned to a transaction.
+    async fn external_id_already_used(
+        &self,
+        relayer_id: &RelayerId,
+        external_id: Option<&str>,
+    ) -> Result<bool, PostgresError> {
+        let Some(external_id) = external_id else {
+            return Ok(false);
+        };
+
+        self.db
+            .get_transaction_by_relayer_and_external_id(relayer_id, external_id)
+            .await
+            .map(|transaction| transaction.is_some())
+    }
+
+    /// Checks for a pre-existing idempotent result before nonce reservation.
+    async fn check_idempotent_existing_transaction(
+        &self,
+        relayer_id: &RelayerId,
+        transaction_to_send: &TransactionToSend,
+    ) -> Result<Option<Transaction>, AddTransactionError> {
+        let Some(external_id) = transaction_to_send.external_id.as_deref() else {
+            return Ok(None);
+        };
+
+        let Some(transaction) = self.load_idempotent_transaction(relayer_id, external_id).await?
+        else {
+            return Ok(None);
+        };
+
+        let transaction = Self::resolve_idempotent_transaction(
+            transaction,
+            relayer_id,
+            transaction_to_send,
+            external_id,
+        )?;
+        info!(
+            %relayer_id,
+            external_id,
+            transaction_id = %transaction.id,
+            "Returning existing idempotent transaction"
+        );
+        Ok(Some(transaction))
+    }
+
+    /// Recovers an idempotent result after a concurrent insert wins the unique-index race.
+    async fn resolve_idempotent_insert_conflict(
+        &self,
+        relayer_id: &RelayerId,
+        transaction_to_send: &TransactionToSend,
+        external_id: &str,
+    ) -> Result<Transaction, AddTransactionError> {
+        let existing = self
+            .load_idempotent_transaction(relayer_id, external_id)
+            .await?
+            .ok_or_else(|| AddTransactionError::ExternalIdPayloadMismatch {
+                relayer_id: *relayer_id,
+                external_id: external_id.to_string(),
+            })?;
+
+        let transaction = Self::resolve_idempotent_transaction(
+            existing,
+            relayer_id,
+            transaction_to_send,
+            external_id,
+        )?;
+        info!(
+            %relayer_id,
+            external_id,
+            transaction_id = %transaction.id,
+            "Returning existing idempotent transaction after insert conflict"
+        );
+        Ok(transaction)
+    }
+
+    /// Returns the external id when a DB error is the idempotency unique-index race.
+    fn idempotent_insert_conflict_external_id<'a>(
+        error: &PostgresError,
+        transaction_to_send: &'a TransactionToSend,
+    ) -> Option<&'a str> {
+        let external_id = transaction_to_send.external_id.as_deref()?;
+        error.is_unique_violation_on(TRANSACTION_EXTERNAL_ID_UNIQUE_INDEX).then_some(external_id)
+    }
+
+    /// Persists deterministic simulation failures or resolves the winning duplicate insert.
+    async fn save_failed_simulation_or_resolve_conflict(
+        &self,
+        relayer_id: &RelayerId,
+        transaction: &Transaction,
+        transaction_to_send: &TransactionToSend,
+        failed_reason: &str,
+    ) -> Result<Option<Transaction>, AddTransactionError> {
+        match self.db.transaction_failed_on_send(relayer_id, transaction, failed_reason).await {
+            Ok(()) => Ok(None),
+            Err(error) => {
+                let Some(external_id) =
+                    Self::idempotent_insert_conflict_external_id(&error, transaction_to_send)
+                else {
+                    return Err(AddTransactionError::CouldNotSaveTransactionDb(error));
+                };
+
+                self.resolve_idempotent_insert_conflict(
+                    relayer_id,
+                    transaction_to_send,
+                    external_id,
+                )
+                .await
+                .map(Some)
+            }
+        }
     }
 
     /// Converts a transaction to a no-op transaction.
@@ -322,7 +542,7 @@ impl TransactionsQueues {
             .estimate_gas(&temp_transaction_request, transaction.is_noop)
             .await
             .map_err(|e| {
-                AddTransactionError::TransactionEstimateGasError(transaction.relayer_id, e)
+                AddTransactionError::transaction_estimate_gas_error(transaction.relayer_id, e)
             })?;
 
         let relayer_balance = transactions_queue.get_balance().await.map_err(|e| {
@@ -361,6 +581,12 @@ impl TransactionsQueues {
             .get_transactions_queue(relayer_id)
             .ok_or(AddTransactionError::RelayerNotFound(*relayer_id))?;
 
+        if let Some(transaction) =
+            self.check_idempotent_existing_transaction(relayer_id, transaction_to_send).await?
+        {
+            return Ok(transaction);
+        }
+
         let mut transactions_queue = queue_arc.lock().await;
 
         if transactions_queue.is_paused() {
@@ -375,15 +601,6 @@ impl TransactionsQueues {
             });
         }
 
-        // Sync nonce manager with on-chain nonce to ensure consistency
-        let current_onchain_nonce = transactions_queue
-            .get_nonce()
-            .await
-            .map_err(|e| AddTransactionError::CouldNotGetCurrentOnChainNonce(*relayer_id, e))?;
-
-        transactions_queue.nonce_manager.sync_with_onchain_nonce(current_onchain_nonce).await;
-        let assigned_nonce = transactions_queue.nonce_manager.get_and_increment().await;
-
         let mut transaction = Transaction {
             id: transaction_to_send.id,
             relayer_id: *relayer_id,
@@ -391,7 +608,8 @@ impl TransactionsQueues {
             from: transactions_queue.relay_address(),
             value: transaction_to_send.value,
             data: transaction_to_send.data.clone(),
-            nonce: assigned_nonce,
+            // placeholder nonce, will be set to the next available nonce from the nonce manager.
+            nonce: TransactionNonce::new(0),
             gas_limit: None,
             status: TransactionStatus::PENDING,
             blobs: transaction_to_send.blobs.clone(),
@@ -430,22 +648,36 @@ impl TransactionsQueues {
 
         let estimated_gas_limit = match estimated_gas_limit {
             Ok(limit) => limit,
-            Err(err) => {
-                self.db
-                    .transaction_failed_on_send(
+            Err(err @ AddTransactionError::TransactionSimulationReverted(_, _)) => {
+                let failed_reason = err.to_string();
+                if let Some(existing) = self
+                    .save_failed_simulation_or_resolve_conflict(
                         relayer_id,
                         &transaction,
-                        "Failed to send transaction as always failing on gas estimation",
+                        transaction_to_send,
+                        &failed_reason,
                     )
-                    .await
-                    .map_err(AddTransactionError::CouldNotSaveTransactionDb)?;
+                    .await?
+                {
+                    return Ok(existing);
+                }
 
                 self.invalidate_transaction_cache(&transaction.id).await;
                 return Err(err);
             }
+            Err(err) => return Err(err),
         };
 
         transaction.gas_limit = Some(estimated_gas_limit);
+
+        let current_onchain_nonce = transactions_queue
+            .get_nonce()
+            .await
+            .map_err(|e| AddTransactionError::CouldNotGetCurrentOnChainNonce(*relayer_id, e))?;
+
+        transactions_queue.nonce_manager.sync_with_onchain_nonce(current_onchain_nonce).await;
+        let nonce_reservation = transactions_queue.nonce_manager.reserve_next().await;
+        transaction.nonce = nonce_reservation.nonce();
 
         let transaction_request = Self::create_typed_transaction(
             &transactions_queue,
@@ -458,13 +690,30 @@ impl TransactionsQueues {
         transaction.known_transaction_hash =
             Some(transactions_queue.compute_tx_hash(&transaction_request).await?);
 
-        self.db
-            .save_transaction(relayer_id, &transaction)
-            .await
-            .map_err(AddTransactionError::CouldNotSaveTransactionDb)?;
+        match self.db.save_transaction(relayer_id, &transaction).await {
+            Ok(()) => {}
+            Err(error) => {
+                let Some(external_id) =
+                    Self::idempotent_insert_conflict_external_id(&error, transaction_to_send)
+                else {
+                    return Err(AddTransactionError::CouldNotSaveTransactionDb(error));
+                };
+
+                drop(nonce_reservation);
+                return self
+                    .resolve_idempotent_insert_conflict(
+                        relayer_id,
+                        transaction_to_send,
+                        external_id,
+                    )
+                    .await;
+            }
+        }
 
         transactions_queue.add_pending_transaction(transaction.clone()).await;
-        // Nonce already incremented atomically above - no need for separate increase call
+        // release the nonce manager lock after the transaction has been successfully added to the queue.
+        // releasing the nonce manager lock too soon may cause downstream failures to lead to eager (and faulty) nonce increment.
+        nonce_reservation.commit();
         self.invalidate_transaction_cache(&transaction.id).await;
 
         if let Some(webhook_manager) = &self.webhook_manager {
@@ -573,6 +822,22 @@ impl TransactionsQueues {
                             external_id: Some(format!("cancel_{}", transaction.id)),
                             cancelled_by_transaction_id: None,
                         };
+
+                        if let Some(external_id) = cancel_transaction.external_id.as_deref() {
+                            if self
+                                .external_id_already_used(
+                                    &transaction.relayer_id,
+                                    Some(external_id),
+                                )
+                                .await
+                                .map_err(CancelTransactionError::CouldNotReadTransactionDb)?
+                            {
+                                return Err(CancelTransactionError::ExternalIdAlreadyUsed {
+                                    relayer_id: transaction.relayer_id,
+                                    external_id: external_id.to_string(),
+                                });
+                            }
+                        }
 
                         info!("cancel_transaction: creating higher gas cancel transaction for inmempool tx with same nonce {:?}", cancel_transaction.nonce);
 
@@ -821,6 +1086,22 @@ impl TransactionsQueues {
                                 .or_else(|| Some(format!("replace_{}", transaction.id))),
                             cancelled_by_transaction_id: None,
                         };
+
+                        if let Some(external_id) = replace_transaction.external_id.as_deref() {
+                            if self
+                                .external_id_already_used(
+                                    &transaction.relayer_id,
+                                    Some(external_id),
+                                )
+                                .await
+                                .map_err(ReplaceTransactionError::CouldNotReadTransactionDb)?
+                            {
+                                return Err(ReplaceTransactionError::ExternalIdAlreadyUsed {
+                                    relayer_id: transaction.relayer_id,
+                                    external_id: external_id.to_string(),
+                                });
+                            }
+                        }
 
                         info!("replace_transaction: creating competitive replace transaction for inmempool tx with same nonce {:?}", replace_transaction.nonce);
 
@@ -1177,8 +1458,10 @@ impl TransactionsQueues {
                                         ));
                                     }
 
-                                    let new_nonce =
-                                        transactions_queue.nonce_manager.get_and_increment().await;
+                                    let nonce_reservation =
+                                        transactions_queue.nonce_manager.reserve_next().await;
+                                    let new_nonce = nonce_reservation.nonce();
+                                    nonce_reservation.commit();
                                     transaction.nonce = new_nonce;
 
                                     transactions_queue
@@ -1477,7 +1760,9 @@ impl TransactionsQueues {
                                                     ));
                                                 }
 
-                                                let new_nonce = transactions_queue.nonce_manager.get_and_increment().await;
+                                                let nonce_reservation = transactions_queue.nonce_manager.reserve_next().await;
+                                                let new_nonce = nonce_reservation.nonce();
+                                                nonce_reservation.commit();
                                                 transaction.nonce = new_nonce;
 
                                                 transactions_queue.update_inmempool_transaction_nonce(&transaction.id, new_nonce).await;
@@ -1688,5 +1973,176 @@ impl TransactionsQueues {
         } else {
             Err(ProcessMinedTransactionError::RelayerTransactionsQueueNotFound(*relayer_id))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, VecDeque};
+
+    use alloy::primitives::{TxHash, U256};
+    use chrono::Utc;
+
+    use super::TransactionsQueues;
+    use crate::{
+        network::ChainId,
+        relayer::RelayerId,
+        shared::common_types::EvmAddress,
+        transaction::{
+            queue_system::types::{CompetitionType, CompetitiveTransaction, TransactionToSend},
+            types::{
+                Transaction, TransactionData, TransactionHash, TransactionId, TransactionNonce,
+                TransactionSpeed, TransactionStatus, TransactionValue,
+            },
+        },
+    };
+
+    fn transaction_with_nonce(status: TransactionStatus, nonce: u64) -> Transaction {
+        Transaction {
+            id: TransactionId::new(),
+            relayer_id: RelayerId::new(),
+            to: EvmAddress::zero(),
+            from: EvmAddress::zero(),
+            value: TransactionValue::zero(),
+            data: TransactionData::empty(),
+            nonce: TransactionNonce::new(nonce),
+            gas_limit: None,
+            status,
+            blobs: None,
+            chain_id: ChainId::new(1),
+            known_transaction_hash: None,
+            queued_at: Utc::now(),
+            expires_at: Utc::now(),
+            sent_at: None,
+            mined_at: None,
+            mined_at_block_number: None,
+            confirmed_at: None,
+            speed: TransactionSpeed::FAST,
+            sent_with_max_priority_fee_per_gas: None,
+            sent_with_max_fee_per_gas: None,
+            is_noop: false,
+            sent_with_gas: None,
+            sent_with_blob_gas: None,
+            external_id: None,
+            cancelled_by_transaction_id: None,
+        }
+    }
+
+    fn to_transaction_to_send(transaction: &Transaction) -> TransactionToSend {
+        TransactionToSend::new(
+            transaction.to,
+            transaction.value,
+            transaction.data.clone(),
+            Some(transaction.speed.clone()),
+            transaction.blobs.clone(),
+            transaction.external_id.clone(),
+        )
+    }
+
+    #[test]
+    fn next_nonce_after_open_transactions_ignores_failed_rows() {
+        let mut pending = VecDeque::new();
+        pending.push_back(transaction_with_nonce(TransactionStatus::FAILED, 99));
+        pending.push_back(transaction_with_nonce(TransactionStatus::PENDING, 3));
+
+        let next_nonce = TransactionsQueues::next_nonce_after_open_transactions(
+            &pending,
+            &VecDeque::new(),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(next_nonce, TransactionNonce::new(4));
+    }
+
+    #[test]
+    fn next_nonce_after_open_transactions_counts_inmempool_and_mined() {
+        let mut inmempool = VecDeque::new();
+        let mut competitive =
+            CompetitiveTransaction::new(transaction_with_nonce(TransactionStatus::INMEMPOOL, 7));
+        competitive.add_competitor(
+            transaction_with_nonce(TransactionStatus::INMEMPOOL, 7),
+            CompetitionType::Replace,
+        );
+        inmempool.push_back(competitive);
+
+        let mined_transaction = transaction_with_nonce(TransactionStatus::MINED, 12);
+        let mut mined = HashMap::new();
+        mined.insert(mined_transaction.id, mined_transaction);
+
+        let next_nonce = TransactionsQueues::next_nonce_after_open_transactions(
+            &VecDeque::new(),
+            &inmempool,
+            &mined,
+        )
+        .unwrap();
+
+        assert_eq!(next_nonce, TransactionNonce::new(13));
+    }
+
+    #[test]
+    fn idempotent_resolve_returns_matching_transaction_with_hash() {
+        let relayer_id = RelayerId::new();
+        let mut transaction = transaction_with_nonce(TransactionStatus::PENDING, 1);
+        transaction.relayer_id = relayer_id;
+        transaction.external_id = Some("idempotent-key".to_string());
+        transaction.known_transaction_hash = Some(TransactionHash::new(TxHash::ZERO));
+
+        let transaction_to_send = to_transaction_to_send(&transaction);
+
+        let resolved = TransactionsQueues::resolve_idempotent_transaction(
+            transaction.clone(),
+            &relayer_id,
+            &transaction_to_send,
+            "idempotent-key",
+        )
+        .unwrap();
+
+        assert_eq!(resolved.id, transaction.id);
+    }
+
+    #[test]
+    fn idempotent_resolve_rejects_payload_mismatch() {
+        let relayer_id = RelayerId::new();
+        let mut transaction = transaction_with_nonce(TransactionStatus::PENDING, 1);
+        transaction.relayer_id = relayer_id;
+        transaction.external_id = Some("idempotent-key".to_string());
+
+        let mut transaction_to_send = to_transaction_to_send(&transaction);
+        transaction_to_send.value = TransactionValue::new(U256::from(1_u128));
+
+        let result = TransactionsQueues::resolve_idempotent_transaction(
+            transaction,
+            &relayer_id,
+            &transaction_to_send,
+            "idempotent-key",
+        );
+
+        assert!(matches!(
+            result,
+            Err(super::AddTransactionError::ExternalIdPayloadMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn idempotent_resolve_returns_bad_request_for_prior_failed_simulation() {
+        let relayer_id = RelayerId::new();
+        let mut transaction = transaction_with_nonce(TransactionStatus::FAILED, 1);
+        transaction.relayer_id = relayer_id;
+        transaction.external_id = Some("idempotent-key".to_string());
+
+        let transaction_to_send = to_transaction_to_send(&transaction);
+
+        let result = TransactionsQueues::resolve_idempotent_transaction(
+            transaction,
+            &relayer_id,
+            &transaction_to_send,
+            "idempotent-key",
+        );
+
+        assert!(matches!(
+            result,
+            Err(super::AddTransactionError::IdempotentTransactionFailed { .. })
+        ));
     }
 }

--- a/crates/core/src/transaction/queue_system/types/transactions_queues_custom_errors.rs
+++ b/crates/core/src/transaction/queue_system/types/transactions_queues_custom_errors.rs
@@ -1,13 +1,18 @@
 use std::time::SystemTimeError;
 
-use alloy::transports::{RpcError, TransportErrorKind};
+use alloy::{
+    rpc::json_rpc::ErrorPayload,
+    transports::{RpcError, TransportErrorKind},
+};
 use thiserror::Error;
 
 use super::{
     SendTransactionGasPriceError, TransactionQueueSendTransactionError, TransactionSentWithRelayer,
 };
 use crate::common_types::EvmAddress;
-use crate::shared::{bad_request, forbidden, internal_server_error, not_found, HttpError};
+use crate::shared::{
+    bad_request, conflict, forbidden, internal_server_error, not_found, HttpError,
+};
 use crate::transaction::types::TransactionConversionError;
 use crate::{
     postgres::PostgresError,
@@ -33,6 +38,12 @@ pub enum ReplaceTransactionError {
     #[error("Relayer could not update the transaction in the db {0}")]
     CouldNotUpdateTransactionInDb(#[from] PostgresError),
 
+    #[error("Transaction could not be read from DB: {0}")]
+    CouldNotReadTransactionDb(PostgresError),
+
+    #[error("external_id {external_id} has already been used for relayer {relayer_id}")]
+    ExternalIdAlreadyUsed { relayer_id: RelayerId, external_id: String },
+
     #[error("Nonce synchronization recovered, replacement transaction should be retried")]
     NonceSynchronizationRecovered,
 }
@@ -47,6 +58,10 @@ impl From<ReplaceTransactionError> for HttpError {
             return forbidden(value.to_string());
         }
 
+        if matches!(value, ReplaceTransactionError::ExternalIdAlreadyUsed { .. }) {
+            return conflict(value.to_string());
+        }
+
         internal_server_error(Some(value.to_string()))
     }
 }
@@ -55,6 +70,9 @@ impl From<ReplaceTransactionError> for HttpError {
 pub enum AddTransactionError {
     #[error("Transaction could not be saved in DB: {0}")]
     CouldNotSaveTransactionDb(PostgresError),
+
+    #[error("Transaction could not be read from DB: {0}")]
+    CouldNotReadTransactionDb(PostgresError),
 
     #[error("Relayer could not be found: {0}")]
     RelayerNotFound(RelayerId),
@@ -74,6 +92,9 @@ pub enum AddTransactionError {
     #[error("could not estimate gas limit - {0}")]
     TransactionEstimateGasError(RelayerId, RpcError<TransportErrorKind>),
 
+    #[error("transaction simulation reverted - {1}")]
+    TransactionSimulationReverted(RelayerId, RpcError<TransportErrorKind>),
+
     #[error("Could not get current on chain nonce for relayer {0} - {1}")]
     CouldNotGetCurrentOnChainNonce(RelayerId, RpcError<TransportErrorKind>),
 
@@ -82,23 +103,71 @@ pub enum AddTransactionError {
 
     #[error("Unsupported transaction type: {message}")]
     UnsupportedTransactionType { message: String },
+
+    #[error("external_id {external_id} has already been used with a different transaction payload for relayer {relayer_id}")]
+    ExternalIdPayloadMismatch { relayer_id: RelayerId, external_id: String },
+
+    #[error("transaction for external_id {external_id} on relayer {relayer_id} previously failed before broadcast")]
+    IdempotentTransactionFailed { relayer_id: RelayerId, external_id: String },
 }
 
 impl From<AddTransactionError> for HttpError {
     fn from(value: AddTransactionError) -> Self {
-        if matches!(value, AddTransactionError::RelayerIsPaused(_)) {
-            return forbidden(value.to_string());
+        match &value {
+            AddTransactionError::RelayerIsPaused(_) => forbidden(value.to_string()),
+            AddTransactionError::RelayerNotFound(_) => not_found(value.to_string()),
+            AddTransactionError::UnsupportedTransactionType { .. }
+            | AddTransactionError::TransactionSimulationReverted(_, _)
+            | AddTransactionError::IdempotentTransactionFailed { .. } => {
+                bad_request(value.to_string())
+            }
+            AddTransactionError::ExternalIdPayloadMismatch { .. } => conflict(value.to_string()),
+            AddTransactionError::CouldNotSaveTransactionDb(_)
+            | AddTransactionError::CouldNotReadTransactionDb(_)
+            | AddTransactionError::CouldNotReadAllowlistsFromDb(_)
+            | AddTransactionError::TransactionGasPriceError(_)
+            | AddTransactionError::ComputeTransactionHashError(_)
+            | AddTransactionError::TransactionEstimateGasError(_, _)
+            | AddTransactionError::CouldNotGetCurrentOnChainNonce(_, _)
+            | AddTransactionError::TransactionConversionError(_) => {
+                internal_server_error(Some(value.to_string()))
+            }
+        }
+    }
+}
+
+impl AddTransactionError {
+    pub fn transaction_estimate_gas_error(
+        relayer_id: RelayerId,
+        error: RpcError<TransportErrorKind>,
+    ) -> Self {
+        if is_deterministic_simulation_revert(&error) {
+            return Self::TransactionSimulationReverted(relayer_id, error);
         }
 
-        if matches!(value, AddTransactionError::RelayerNotFound(_)) {
-            return not_found(value.to_string());
-        }
+        Self::TransactionEstimateGasError(relayer_id, error)
+    }
+}
 
-        if matches!(value, AddTransactionError::UnsupportedTransactionType { .. }) {
-            return bad_request(value.to_string());
-        }
+fn error_payload_is_revert(payload: &ErrorPayload) -> bool {
+    payload.as_revert_data().is_some()
+        || payload.message.to_ascii_lowercase().contains("execution reverted")
+}
 
-        internal_server_error(Some(value.to_string()))
+fn is_deterministic_simulation_revert(error: &RpcError<TransportErrorKind>) -> bool {
+    match error {
+        RpcError::ErrorResp(payload) => error_payload_is_revert(payload),
+        RpcError::DeserError { text, .. } => serde_json::from_str::<ErrorPayload>(text)
+            .map(|payload| error_payload_is_revert(&payload))
+            .unwrap_or(false),
+        RpcError::Transport(TransportErrorKind::Custom(error)) => {
+            error.to_string().to_ascii_lowercase().contains("execution reverted")
+        }
+        RpcError::NullResp
+        | RpcError::UnsupportedFeature(_)
+        | RpcError::LocalUsageError(_)
+        | RpcError::SerError(_)
+        | RpcError::Transport(_) => false,
     }
 }
 
@@ -109,6 +178,12 @@ pub enum CancelTransactionError {
 
     #[error("Could not update transaction in database: {0}")]
     CouldNotUpdateTransactionDb(PostgresError),
+
+    #[error("Transaction could not be read from DB: {0}")]
+    CouldNotReadTransactionDb(PostgresError),
+
+    #[error("external_id {external_id} has already been used for relayer {relayer_id}")]
+    ExternalIdAlreadyUsed { relayer_id: RelayerId, external_id: String },
 
     #[error("Relayer could not be found: {0}")]
     RelayerNotFound(RelayerId),
@@ -128,6 +203,10 @@ impl From<CancelTransactionError> for HttpError {
 
         if matches!(value, CancelTransactionError::RelayerNotFound(_)) {
             return not_found(value.to_string());
+        }
+
+        if matches!(value, CancelTransactionError::ExternalIdAlreadyUsed { .. }) {
+            return conflict(value.to_string());
         }
 
         internal_server_error(Some(value.to_string()))
@@ -246,4 +325,53 @@ pub struct CompetitionResolutionResult {
     pub winner_status: TransactionStatus,
     /// The transaction that lost the race (if there was competition)
     pub loser: Option<Transaction>,
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::{
+        rpc::json_rpc::ErrorPayload,
+        transports::{RpcError, TransportErrorKind},
+    };
+    use reqwest::StatusCode;
+
+    use super::AddTransactionError;
+    use crate::{relayer::RelayerId, shared::HttpError};
+
+    #[test]
+    fn simulation_revert_maps_to_bad_request() {
+        let payload: ErrorPayload = serde_json::from_str(
+            r#"{"code":3,"message":"execution reverted: Multicall3: call failed"}"#,
+        )
+        .unwrap();
+        let error: RpcError<TransportErrorKind> = RpcError::ErrorResp(payload);
+
+        let http_error: HttpError =
+            AddTransactionError::transaction_estimate_gas_error(RelayerId::new(), error).into();
+
+        assert_eq!(http_error.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn transport_failure_stays_server_error() {
+        let error: RpcError<TransportErrorKind> =
+            RpcError::Transport(TransportErrorKind::BackendGone);
+
+        let http_error: HttpError =
+            AddTransactionError::transaction_estimate_gas_error(RelayerId::new(), error).into();
+
+        assert_eq!(http_error.0, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn custom_transport_revert_without_colon_maps_to_bad_request() {
+        let error: RpcError<TransportErrorKind> = RpcError::Transport(TransportErrorKind::Custom(
+            "execution reverted".to_string().into(),
+        ));
+
+        let http_error: HttpError =
+            AddTransactionError::transaction_estimate_gas_error(RelayerId::new(), error).into();
+
+        assert_eq!(http_error.0, StatusCode::BAD_REQUEST);
+    }
 }

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+- chore: simplify CI/CD pipeline — Linux-only PR testing, Docker-only releases (no mac/windows binaries)
+
 ---
 
 ### Breaking changes


### PR DESCRIPTION
### Motivation

`POST` `/transactions/relayers/:relayer_id/send` could reserve and advance a relayer nonce before gas estimation/simulation had fully succeeded. If simulation reverted, the API returned a server error and could leave a `PENDING` transaction row for a transaction that was never broadcast. Client retries could then consume future nonces due to a lack of idempotent handling.

This PR makes sends safer by moving nonce reservation later (while holding a lock from the beginning of the send lifecycle), classifying deterministic simulation failures as client errors, and adding optional per-relayer external_id idempotency so clients can safely retry accepted or failed sends without consuming additional nonces.

### Changes

- Added optional per-relayer `external_id` idempotency with a partial unique index.
- Moved nonce reservation after successful gas estimation/simulation, using a scoped rollback guard.
- Persist deterministic pre-broadcast simulation failures as `FAILED`, not `PENDING`.
- Map deterministic simulation reverts to 400 Bad Request; keep RPC/transport failures retryable.
- Initialize nonce cursor from max(chain pending nonce, highest open local nonce + 1). Previously nonces were only initialized from onchain data which ignored in-flight transactions.
- Preflight cancel/replace duplicate `external_id`s before broadcasting.

### Flow Diagram

```
POST /transactions/relayers/:relayer_id/send
  |
  |  API auth / permissions / rate limit
  v
find relayer queue
  |
  |  if external_id is present:
  v
lookup existing tx by (relayer_id, external_id)
  |
  +-- found + payload mismatch
  |     -> 409 Conflict
  |
  +-- found + hash present
  |     -> return existing id/hash
  |
  +-- found + no hash
  |     -> 400 Bad Request
  |
  +-- not found
        |
        v
lock relayer queue
  |
  +-- relayer paused
  |     -> 403 Forbidden
  |
  +-- unsupported blob tx
  |     -> error
  |
  v
build transaction with placeholder nonce
  |
  v
gas price + gas estimation / simulation
  |
  +-- deterministic simulation revert
  |     |
  |     v
  |   insert FAILED row
  |     |
  |     +-- insert wins
  |     |     -> 400 Bad Request
  |     |
  |     +-- external_id conflict
  |           -> resolve existing tx
  |
  +-- RPC / transport failure
  |     -> server/upstream error, no nonce reserved
  |
  v
sync nonce cursor with on-chain nonce
  |
  v
reserve next nonce
  |
  |  reservation increments cursor and holds guard
  v
assign nonce + compute transaction hash
  |
  +-- build/hash failure
  |     -> drop reservation, rollback cursor
  |
  v
insert PENDING tx row
  |
  +-- external_id conflict
  |     -> drop reservation, rollback cursor
  |     -> resolve existing tx
  |
  +-- other DB failure
  |     -> drop reservation, rollback cursor
  |
  v
add tx to in-memory pending queue
  |
  v
commit nonce reservation
  |
  v
return id/hash

```