### PR TITLE
fix: Use Correct Fields while Logging Transaction Errors

### DIFF
--- a/crates/core/src/transaction/queue_system/types/transactions_queues_custom_errors.rs
+++ b/crates/core/src/transaction/queue_system/types/transactions_queues_custom_errors.rs
@@ -140,23 +140,23 @@ pub enum ProcessPendingTransactionError {
     #[error("Relayer transactions queue not found for relayer id {0}")]
     RelayerTransactionsQueueNotFound(RelayerId),
 
-    #[error("Relayer id {0} / address {1} - Send transaction error: {0}")]
+    #[error("Relayer id {0} / address {1} - Send transaction error: {2}")]
     SendTransactionError(RelayerId, EvmAddress, TransactionQueueSendTransactionError),
 
-    #[error("Transaction could not be sent due to gas calculation error for relayer id {0} / address {1}: tx {1}")]
+    #[error("Transaction could not be sent due to gas calculation error for relayer id {0} / address {1}: tx {2}")]
     GasCalculationError(RelayerId, EvmAddress, Transaction),
 
-    #[error("Relayer id {0} / address {1} - {0}")]
+    #[error("Relayer id {0} / address {1} - {2}")]
     MovePendingTransactionToInmempoolError(
         RelayerId,
         EvmAddress,
         MovePendingTransactionToInmempoolError,
     ),
 
-    #[error("Relayer id {0} / address {1} - Transaction estimate gas error: {0}")]
+    #[error("Relayer id {0} / address {1} - Transaction estimate gas error: {2}")]
     TransactionEstimateGasError(RelayerId, EvmAddress, RpcError<TransportErrorKind>),
 
-    #[error("Relayer id {0} / address {1} - Transaction could not be updated in DB: {0}")]
+    #[error("Relayer id {0} / address {1} - Transaction could not be updated in DB: {2}")]
     DbError(RelayerId, EvmAddress, PostgresError),
 }
 
@@ -165,7 +165,7 @@ pub enum ProcessInmempoolTransactionError {
     #[error("Relayer transactions queue not found for relayer {0}")]
     RelayerTransactionsQueueNotFound(RelayerId),
 
-    #[error("Relayer id {0} / address {1} - Send transaction error: {0}")]
+    #[error("Relayer id {0} / address {1} - Send transaction error: {2}")]
     SendTransactionError(RelayerId, EvmAddress, TransactionQueueSendTransactionError),
 
     #[error(
@@ -179,7 +179,7 @@ pub enum ProcessInmempoolTransactionError {
         PostgresError,
     ),
 
-    #[error("Relayer id {0} / address {1} - {0}")]
+    #[error("Relayer id {0} / address {1} - {2}")]
     MoveInmempoolTransactionToMinedError(
         RelayerId,
         EvmAddress,

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+- fix: use correct fields in string representation of error
+
 ---
 
 ### Breaking changes


### PR DESCRIPTION
The string representation of transactions errors doesn't actually print the error, instead it includes the relayer id twice:
`Relayer id 616a2f2e-d2a8-4a92-96a2-ba37fce63846 / address 0x111115763723b53395308ec4c9ab9d5fb0844cae - Send transaction error: 616a2f2e-d2a8-4a92-96a2-ba37fce63846`

This PR updates the error enums to use the correct tuple element index to print the actual error message.