### PR TITLE
fix: Write Error Message to DB on Failure

### DIFF
--- a/crates/core/src/transaction/db/write.rs
+++ b/crates/core/src/transaction/db/write.rs
@@ -146,7 +146,7 @@ impl PostgresClient {
         &self,
         relayer_id: &RelayerId,
         transaction: &Transaction,
-        failed_reason: &str,
+        failed_reason: String,
     ) -> Result<(), PostgresError> {
         let mut conn = self.pool.get().await?;
         let trans = conn.transaction().await.map_err(PostgresError::PgError)?;

--- a/crates/core/src/transaction/queue_system/transactions_queues.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queues.rs
@@ -435,7 +435,9 @@ impl TransactionsQueues {
                     .transaction_failed_on_send(
                         relayer_id,
                         &transaction,
-                        "Failed to send transaction as always failing on gas estimation",
+                        format!(
+                            "Failed to send transaction as always failing on gas estimation: {err}"
+                        ),
                     )
                     .await
                     .map_err(AddTransactionError::CouldNotSaveTransactionDb)?;

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -12,6 +12,8 @@
 
 ### Bug fixes
 
+- fix: write error message to db on failure
+
 ---
 
 ### Breaking changes


### PR DESCRIPTION
Includes the error message in the db on gas estimation failure to make debugging easier.