### PR TITLE
fix: preserve nonces when cancelling pending transactions

### DIFF
--- a/crates/core/src/provider/evm_provider.rs
+++ b/crates/core/src/provider/evm_provider.rs
@@ -44,17 +44,25 @@ use alloy_eips::eip2718::Encodable2718;
 use rand::{thread_rng, Rng};
 use reqwest::Url;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use thiserror::Error;
+use tokio::sync::Mutex;
 use tracing::info;
 
 pub type RelayerProvider = Box<dyn Provider<AnyNetwork> + Send + Sync>;
+
+#[derive(Clone)]
+struct BlockGasLimitCache {
+    gas_limit: GasLimit,
+    fetched_at: Instant,
+}
 
 #[derive(Clone)]
 pub struct EvmProvider {
     rpc_clients: Vec<Arc<RelayerProvider>>,
     wallet_manager: Arc<dyn WalletManagerTrait>,
     gas_estimator: Arc<dyn BaseGasFeeEstimator + Send + Sync>,
+    block_gas_limit_cache: Arc<Mutex<Option<BlockGasLimitCache>>>,
     pub chain_id: ChainId,
     pub name: String,
     pub provider_urls: Vec<String>,
@@ -273,6 +281,7 @@ impl EvmProvider {
             rpc_clients: providers,
             wallet_manager,
             gas_estimator,
+            block_gas_limit_cache: Arc::new(Mutex::new(None)),
             chain_id,
             name: network_setup_config.name.to_string(),
             provider_urls: network_setup_config.provider_urls.to_owned(),
@@ -446,22 +455,34 @@ impl EvmProvider {
         Ok(GasLimit::new(result as u128))
     }
 
-    /// Returns the latest block gas limit.
+    /// Returns the latest block gas limit, cached for roughly one block.
     ///
     /// A single transaction cannot fit in a block if its gas limit exceeds this value, but this is
     /// not a permanent chain constant. Validators/sequencers can adjust the block gas limit over
-    /// time, so callers should fetch it when validating a transaction instead of caching it
-    /// indefinitely.
-    pub async fn get_latest_block_gas_limit(
-        &self,
-    ) -> Result<GasLimit, RpcError<TransportErrorKind>> {
+    /// time, so the cache is intentionally short-lived.
+    pub async fn get_block_gas_limit(&self) -> Result<GasLimit, RpcError<TransportErrorKind>> {
+        let cache_ttl = Duration::from_millis(self.blocks_every);
+
+        {
+            let cache = self.block_gas_limit_cache.lock().await;
+            if let Some(cached) = cache.as_ref() {
+                if cached.fetched_at.elapsed() < cache_ttl {
+                    return Ok(cached.gas_limit);
+                }
+            }
+        }
+
         let block = self.rpc_client().get_block_by_number(BlockNumberOrTag::Latest).await?.ok_or(
             RpcError::Transport(TransportErrorKind::Custom(
                 "Latest block not found".to_string().into(),
             )),
         )?;
 
-        Ok(GasLimit::new(block.header.gas_limit as u128))
+        let gas_limit = GasLimit::new(block.header.gas_limit as u128);
+        let mut cache = self.block_gas_limit_cache.lock().await;
+        *cache = Some(BlockGasLimitCache { gas_limit, fetched_at: Instant::now() });
+
+        Ok(gas_limit)
     }
 
     pub async fn calculate_gas_price(&self) -> Result<GasEstimatorResult, GasEstimatorError> {

--- a/crates/core/src/provider/evm_provider.rs
+++ b/crates/core/src/provider/evm_provider.rs
@@ -446,6 +446,16 @@ impl EvmProvider {
         Ok(GasLimit::new(result as u128))
     }
 
+    pub async fn get_block_gas_limit(&self) -> Result<GasLimit, RpcError<TransportErrorKind>> {
+        let block = self.rpc_client().get_block_by_number(BlockNumberOrTag::Latest).await?.ok_or(
+            RpcError::Transport(TransportErrorKind::Custom(
+                "Latest block not found".to_string().into(),
+            )),
+        )?;
+
+        Ok(GasLimit::new(block.header.gas_limit as u128))
+    }
+
     pub async fn calculate_gas_price(&self) -> Result<GasEstimatorResult, GasEstimatorError> {
         self.gas_estimator.get_gas_prices(&self.chain_id).await
     }

--- a/crates/core/src/provider/evm_provider.rs
+++ b/crates/core/src/provider/evm_provider.rs
@@ -446,7 +446,15 @@ impl EvmProvider {
         Ok(GasLimit::new(result as u128))
     }
 
-    pub async fn get_block_gas_limit(&self) -> Result<GasLimit, RpcError<TransportErrorKind>> {
+    /// Returns the latest block gas limit.
+    ///
+    /// A single transaction cannot fit in a block if its gas limit exceeds this value, but this is
+    /// not a permanent chain constant. Validators/sequencers can adjust the block gas limit over
+    /// time, so callers should fetch it when validating a transaction instead of caching it
+    /// indefinitely.
+    pub async fn get_latest_block_gas_limit(
+        &self,
+    ) -> Result<GasLimit, RpcError<TransportErrorKind>> {
         let block = self.rpc_client().get_block_by_number(BlockNumberOrTag::Latest).await?.ok_or(
             RpcError::Transport(TransportErrorKind::Custom(
                 "Latest block not found".to_string().into(),

--- a/crates/core/src/provider/evm_provider.rs
+++ b/crates/core/src/provider/evm_provider.rs
@@ -51,6 +51,8 @@ use tracing::info;
 
 pub type RelayerProvider = Box<dyn Provider<AnyNetwork> + Send + Sync>;
 
+const BLOCK_GAS_LIMIT_CACHE_TTL: Duration = Duration::from_secs(30);
+
 #[derive(Clone)]
 struct BlockGasLimitCache {
     gas_limit: GasLimit,
@@ -455,18 +457,16 @@ impl EvmProvider {
         Ok(GasLimit::new(result as u128))
     }
 
-    /// Returns the latest block gas limit, cached for roughly one block.
+    /// Returns the latest block gas limit, cached briefly to avoid repeated RPC calls.
     ///
     /// A single transaction cannot fit in a block if its gas limit exceeds this value, but this is
     /// not a permanent chain constant. Validators/sequencers can adjust the block gas limit over
     /// time, so the cache is intentionally short-lived.
     pub async fn get_block_gas_limit(&self) -> Result<GasLimit, RpcError<TransportErrorKind>> {
-        let cache_ttl = Duration::from_millis(self.blocks_every);
-
         {
             let cache = self.block_gas_limit_cache.lock().await;
             if let Some(cached) = cache.as_ref() {
-                if cached.fetched_at.elapsed() < cache_ttl {
+                if cached.fetched_at.elapsed() < BLOCK_GAS_LIMIT_CACHE_TTL {
                     return Ok(cached.gas_limit);
                 }
             }

--- a/crates/core/src/transaction/queue_system/transactions_queue.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queue.rs
@@ -1063,7 +1063,7 @@ impl TransactionsQueue {
             })?;
 
         if !is_noop {
-            let block_gas_limit = self.evm_provider.get_latest_block_gas_limit().await?;
+            let block_gas_limit = self.evm_provider.get_block_gas_limit().await?;
             if estimated_gas_result > block_gas_limit {
                 return Err(RpcError::Transport(TransportErrorKind::Custom(
                     format!(
@@ -1109,7 +1109,7 @@ impl TransactionsQueue {
         &self,
         gas_limit: GasLimit,
     ) -> Result<(), RpcError<TransportErrorKind>> {
-        let block_gas_limit = self.evm_provider.get_latest_block_gas_limit().await?;
+        let block_gas_limit = self.evm_provider.get_block_gas_limit().await?;
         if gas_limit > block_gas_limit {
             return Err(RpcError::Transport(TransportErrorKind::Custom(
                 format!(

--- a/crates/core/src/transaction/queue_system/transactions_queue.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queue.rs
@@ -324,6 +324,22 @@ impl TransactionsQueue {
         }
     }
 
+    pub async fn update_pending_transaction(&mut self, updated_transaction: Transaction) -> bool {
+        let mut transactions = self.pending_transactions.lock().await;
+        if let Some(transaction) =
+            transactions.iter_mut().find(|tx| tx.id == updated_transaction.id)
+        {
+            *transaction = updated_transaction;
+            info!(
+                "Updated pending transaction {} for relayer {}",
+                transaction.id, self.relayer.name
+            );
+            true
+        } else {
+            false
+        }
+    }
+
     pub async fn add_competitor_to_inmempool_transaction(
         &mut self,
         original_transaction_id: &TransactionId,
@@ -1047,7 +1063,31 @@ impl TransactionsQueue {
             })?;
 
         if !is_noop {
-            let estimated_gas = estimated_gas_result * 12 / 10;
+            let block_gas_limit = self.evm_provider.get_block_gas_limit().await?;
+            if estimated_gas_result > block_gas_limit {
+                return Err(RpcError::Transport(TransportErrorKind::Custom(
+                    format!(
+                        "Estimated gas {} exceeds latest block gas limit {}",
+                        estimated_gas_result.into_inner(),
+                        block_gas_limit.into_inner()
+                    )
+                    .into(),
+                )));
+            }
+
+            let buffered_gas = estimated_gas_result * 12 / 10;
+            let estimated_gas = std::cmp::min(buffered_gas, block_gas_limit);
+            if estimated_gas < buffered_gas {
+                info!(
+                    "Gas estimation for relayer: {} - base: {}, buffered: {}, capped to block gas limit: {}",
+                    self.relayer.name,
+                    estimated_gas_result.into_inner(),
+                    buffered_gas.into_inner(),
+                    block_gas_limit.into_inner()
+                );
+                return Ok(estimated_gas);
+            }
+
             info!(
                 "Gas estimation for relayer: {} - base: {}, with 20% buffer: {}",
                 self.relayer.name,
@@ -1063,6 +1103,25 @@ impl TransactionsQueue {
             estimated_gas_result.into_inner()
         );
         Ok(estimated_gas_result)
+    }
+
+    async fn validate_gas_limit_within_block_cap(
+        &self,
+        gas_limit: GasLimit,
+    ) -> Result<(), RpcError<TransportErrorKind>> {
+        let block_gas_limit = self.evm_provider.get_block_gas_limit().await?;
+        if gas_limit > block_gas_limit {
+            return Err(RpcError::Transport(TransportErrorKind::Custom(
+                format!(
+                    "Transaction gas limit {} exceeds latest block gas limit {}",
+                    gas_limit.into_inner(),
+                    block_gas_limit.into_inner()
+                )
+                .into(),
+            )));
+        }
+
+        Ok(())
     }
 
     pub async fn send_transaction(
@@ -1252,6 +1311,10 @@ impl TransactionsQueue {
                 estimated_gas_limit.into_inner()
             );
         }
+
+        self.validate_gas_limit_within_block_cap(estimated_gas_limit)
+            .await
+            .map_err(TransactionQueueSendTransactionError::TransactionEstimateGasError)?;
 
         working_transaction.gas_limit = Some(estimated_gas_limit);
         transaction.gas_limit = Some(estimated_gas_limit);

--- a/crates/core/src/transaction/queue_system/transactions_queue.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queue.rs
@@ -1063,7 +1063,7 @@ impl TransactionsQueue {
             })?;
 
         if !is_noop {
-            let block_gas_limit = self.evm_provider.get_block_gas_limit().await?;
+            let block_gas_limit = self.evm_provider.get_latest_block_gas_limit().await?;
             if estimated_gas_result > block_gas_limit {
                 return Err(RpcError::Transport(TransportErrorKind::Custom(
                     format!(
@@ -1109,7 +1109,7 @@ impl TransactionsQueue {
         &self,
         gas_limit: GasLimit,
     ) -> Result<(), RpcError<TransportErrorKind>> {
-        let block_gas_limit = self.evm_provider.get_block_gas_limit().await?;
+        let block_gas_limit = self.evm_provider.get_latest_block_gas_limit().await?;
         if gas_limit > block_gas_limit {
             return Err(RpcError::Transport(TransportErrorKind::Custom(
                 format!(

--- a/crates/core/src/transaction/queue_system/transactions_queues.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queues.rs
@@ -505,10 +505,19 @@ impl TransactionsQueues {
 
                 match result.type_name {
                     EditableTransactionType::Pending => {
-                        info!("cancel_transaction: removing pending transaction from queue and marking as cancelled");
+                        info!("cancel_transaction: converting pending transaction to no-op so its nonce is consumed");
 
-                        result.transaction.status = TransactionStatus::CANCELLED;
-                        transactions_queue.remove_pending_transaction_by_id(&transaction.id).await;
+                        self.transaction_to_noop(&mut transactions_queue, &mut result.transaction);
+                        result.transaction.known_transaction_hash = None;
+                        result.transaction.sent_with_gas = None;
+                        result.transaction.sent_with_blob_gas = None;
+                        result.transaction.sent_with_max_fee_per_gas = None;
+                        result.transaction.sent_with_max_priority_fee_per_gas = None;
+                        result.transaction.sent_at = None;
+                        result.transaction.status = TransactionStatus::PENDING;
+                        transactions_queue
+                            .update_pending_transaction(result.transaction.clone())
+                            .await;
 
                         self.db
                             .transaction_update(&result.transaction)

--- a/crates/e2e-tests/src/tests/test_runner.rs
+++ b/crates/e2e-tests/src/tests/test_runner.rs
@@ -310,11 +310,7 @@ impl TestRunner {
             info!("Transaction {} status: {:?}", transaction_id, result);
 
             match result.status {
-                TransactionStatus::CONFIRMED
-                | TransactionStatus::MINED
-                | TransactionStatus::DROPPED
-                | TransactionStatus::CANCELLED
-                | TransactionStatus::REPLACED => {
+                TransactionStatus::CONFIRMED | TransactionStatus::MINED => {
                     info!("Transaction {} completed successfully", transaction_id);
                     let transaction = self
                         .relayer_client
@@ -326,6 +322,68 @@ impl TestRunner {
                         transaction,
                         result.receipt.expect("Transaction receipt should always be present now"),
                     ));
+                }
+                TransactionStatus::DROPPED
+                | TransactionStatus::CANCELLED
+                | TransactionStatus::REPLACED => {
+                    anyhow::bail!(
+                        "Transaction {} reached terminal status {} without a mined receipt",
+                        transaction_id,
+                        result.status
+                    );
+                }
+                TransactionStatus::FAILED => {
+                    anyhow::bail!("Transaction {} failed: {:?}", transaction_id, result);
+                }
+                TransactionStatus::PENDING | TransactionStatus::INMEMPOOL => {
+                    info!(
+                        "Transaction {} still pending, mining a block and waiting...",
+                        transaction_id
+                    );
+                    self.mine_and_wait().await?;
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                TransactionStatus::EXPIRED => {
+                    anyhow::bail!("Transaction {} expired: {:?}", transaction_id, result);
+                }
+            }
+        }
+    }
+
+    pub async fn wait_for_transaction_terminal(
+        &self,
+        transaction_id: &TransactionId,
+    ) -> anyhow::Result<Transaction> {
+        let timeout = Duration::from_secs(self.config.test_timeout_seconds);
+        let start = tokio::time::Instant::now();
+
+        loop {
+            if start.elapsed() > timeout {
+                anyhow::bail!(
+                    "Transaction {} timed out after {} seconds",
+                    transaction_id,
+                    self.config.test_timeout_seconds
+                );
+            }
+
+            let result = self.relayer_client.get_transaction_status(transaction_id).await?;
+            info!("Transaction {} status: {:?}", transaction_id, result);
+
+            match result.status {
+                TransactionStatus::CONFIRMED
+                | TransactionStatus::MINED
+                | TransactionStatus::DROPPED
+                | TransactionStatus::CANCELLED
+                | TransactionStatus::REPLACED => {
+                    info!(
+                        "Transaction {} reached terminal status {}",
+                        transaction_id, result.status
+                    );
+                    return self
+                        .relayer_client
+                        .get_transaction(transaction_id)
+                        .await
+                        .context("Could not get the transaction");
                 }
                 TransactionStatus::FAILED => {
                     anyhow::bail!("Transaction {} failed: {:?}", transaction_id, result);

--- a/crates/e2e-tests/src/tests/transactions/cancel.rs
+++ b/crates/e2e-tests/src/tests/transactions/cancel.rs
@@ -60,11 +60,11 @@ impl TestRunner {
             return Err(anyhow::anyhow!("Cancel transaction failed"));
         }
 
-        self.wait_for_transaction_completion(&send_result.id)
+        let transaction = self
+            .wait_for_transaction_terminal(&send_result.id)
             .await
             .context("Cancelled transaction did not complete as a no-op")?;
 
-        let transaction = self.relayer_client.get_transaction(&send_result.id).await?;
         if !transaction.is_noop {
             return Err(anyhow::anyhow!(
                 "Expected the transaction to be a no-op {}",

--- a/crates/e2e-tests/src/tests/transactions/cancel.rs
+++ b/crates/e2e-tests/src/tests/transactions/cancel.rs
@@ -1,7 +1,7 @@
 use crate::tests::test_runner::TestRunner;
 use anyhow::Context;
 use rrelayer_core::transaction::api::{RelayTransactionRequest, TransactionSpeed};
-use rrelayer_core::transaction::types::{TransactionData, TransactionStatus};
+use rrelayer_core::transaction::types::TransactionData;
 use tracing::info;
 
 impl TestRunner {
@@ -33,6 +33,21 @@ impl TestRunner {
             .await
             .context("Failed to send transaction")?;
 
+        let next_tx_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[2],
+            value: alloy::primitives::utils::parse_ether("0.1")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::SLOW),
+            external_id: Some("test-after-cancel".to_string()),
+            blobs: None,
+        };
+
+        let next_send_result = relayer
+            .transaction()
+            .send(&next_tx_request, None)
+            .await
+            .context("Failed to send follow-up transaction")?;
+
         let transaction_id = &send_result.id;
 
         let cancel_result = relayer
@@ -45,23 +60,9 @@ impl TestRunner {
             return Err(anyhow::anyhow!("Cancel transaction failed"));
         }
 
-        self.anvil_manager.mine_and_wait().await?;
-        let mut attempts = 0;
-        loop {
-            if attempts > 10 {
-                return Err(anyhow::anyhow!("Cancel transaction failed"));
-            }
-            let result = self.relayer_client.get_transaction_status(&send_result.id).await?;
-            if result.status == TransactionStatus::MINED
-                || result.status == TransactionStatus::EXPIRED
-                || result.status == TransactionStatus::CANCELLED
-            {
-                break;
-            } else {
-                attempts += 1;
-                self.anvil_manager.mine_and_wait().await?;
-            }
-        }
+        self.wait_for_transaction_completion(&send_result.id)
+            .await
+            .context("Cancelled transaction did not complete as a no-op")?;
 
         let transaction = self.relayer_client.get_transaction(&send_result.id).await?;
         if !transaction.is_noop {
@@ -69,6 +70,15 @@ impl TestRunner {
                 "Expected the transaction to be a no-op {}",
                 transaction_id
             ));
+        }
+
+        let next_transaction = self
+            .wait_for_transaction_completion(&next_send_result.id)
+            .await
+            .context("Follow-up transaction did not complete after cancelling prior nonce")?;
+
+        if next_transaction.0.is_noop {
+            return Err(anyhow::anyhow!("Expected the follow-up transaction to stay intact"));
         }
 
         info!("[SUCCESS] Transaction {} cancel operation works correctly", transaction_id);

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+- fix: preserve transaction nonce order when cancelling pending transactions
+
 ---
 
 ### Breaking changes


### PR DESCRIPTION
## Summary
- Convert cancelled pending transactions into no-op self-sends so their reserved nonce is still consumed.
- Validate transaction gas limits against the latest block gas limit and cap the 20% estimation buffer at the block cap.
- Extend the cancel e2e test to queue a follow-up transaction and verify it is not stuck behind the cancelled nonce.

## Testing
- cargo check -p rrelayer_core -p rrelayer_e2e_tests
- cargo test -p rrelayer_core --lib

Note: I could not run the Postgres-backed e2e locally because Docker is not reachable in this workspace.

Fixes #99