### PR TITLE
Fix pending transaction gas failure handling

### DIFF
--- a/crates/core/src/transaction/queue_system/transactions_queues.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queues.rs
@@ -382,7 +382,6 @@ impl TransactionsQueues {
             .map_err(|e| AddTransactionError::CouldNotGetCurrentOnChainNonce(*relayer_id, e))?;
 
         transactions_queue.nonce_manager.sync_with_onchain_nonce(current_onchain_nonce).await;
-        let assigned_nonce = transactions_queue.nonce_manager.get_and_increment().await;
 
         let mut transaction = Transaction {
             id: transaction_to_send.id,
@@ -391,7 +390,7 @@ impl TransactionsQueues {
             from: transactions_queue.relay_address(),
             value: transaction_to_send.value,
             data: transaction_to_send.data.clone(),
-            nonce: assigned_nonce,
+            nonce: current_onchain_nonce,
             gas_limit: None,
             status: TransactionStatus::PENDING,
             blobs: transaction_to_send.blobs.clone(),
@@ -431,10 +430,12 @@ impl TransactionsQueues {
         let estimated_gas_limit = match estimated_gas_limit {
             Ok(limit) => limit,
             Err(err) => {
+                let failed_transaction =
+                    Transaction { status: TransactionStatus::FAILED, ..transaction };
                 self.db
                     .transaction_failed_on_send(
                         relayer_id,
-                        &transaction,
+                        &failed_transaction,
                         format!(
                             "Failed to send transaction as always failing on gas estimation: {err}"
                         ),
@@ -447,6 +448,8 @@ impl TransactionsQueues {
             }
         };
 
+        let assigned_nonce = transactions_queue.nonce_manager.get_and_increment().await;
+        transaction.nonce = assigned_nonce;
         transaction.gas_limit = Some(estimated_gas_limit);
 
         let transaction_request = Self::create_typed_transaction(
@@ -466,7 +469,6 @@ impl TransactionsQueues {
             .map_err(AddTransactionError::CouldNotSaveTransactionDb)?;
 
         transactions_queue.add_pending_transaction(transaction.clone()).await;
-        // Nonce already incremented atomically above - no need for separate increase call
         self.invalidate_transaction_cache(&transaction.id).await;
 
         if let Some(webhook_manager) = &self.webhook_manager {
@@ -1072,10 +1074,13 @@ impl TransactionsQueues {
                                 ))
                             }
                             TransactionQueueSendTransactionError::GasCalculationError => {
-                                Err(ProcessPendingTransactionError::GasCalculationError(
-                                    *relayer_id,
-                                    relayer_address,
-                                    transaction.clone(),
+                                error!(
+                                    "process_single_pending: transaction {} could not calculate gas; leaving pending for retry",
+                                    transaction.id
+                                );
+                                Ok(ProcessResult::<ProcessPendingStatus>::other(
+                                    ProcessPendingStatus::GasCalculationUnavailable,
+                                    self.relayer_block_times_ms.get(relayer_id),
                                 ))
                             }
                             TransactionQueueSendTransactionError::TransactionEstimateGasError(
@@ -1220,15 +1225,13 @@ impl TransactionsQueues {
                             TransactionQueueSendTransactionError::SendTransactionGasPriceError(
                                 error,
                             ) => {
-                                // should never happen if it does something internal is wrong,
-                                // and we don't want to
-                                // continue processing the queue
-                                // it can stay in a loop forever, so we don't fail pending
-                                // transactions
-                                Err(ProcessPendingTransactionError::SendTransactionError(
-                                    *relayer_id,
-                                    relayer_address,
-                                    TransactionQueueSendTransactionError::SendTransactionGasPriceError(error),
+                                error!(
+                                    "process_single_pending: transaction {} could not calculate gas price - {}; leaving pending for retry",
+                                    transaction.id, error
+                                );
+                                Ok(ProcessResult::<ProcessPendingStatus>::other(
+                                    ProcessPendingStatus::GasCalculationUnavailable,
+                                    self.relayer_block_times_ms.get(relayer_id),
                                 ))
                             }
                             TransactionQueueSendTransactionError::TransactionConversionError(

--- a/crates/core/src/transaction/queue_system/types/process_queue_result.rs
+++ b/crates/core/src/transaction/queue_system/types/process_queue_result.rs
@@ -30,6 +30,7 @@ pub enum ProcessPendingStatus {
     RelayerPaused,
     NoPendingTransactions,
     GasPriceTooHigh,
+    GasCalculationUnavailable,
     NonceSynchronized,
 }
 

--- a/crates/core/src/transaction/queue_system/types/transactions_queues_custom_errors.rs
+++ b/crates/core/src/transaction/queue_system/types/transactions_queues_custom_errors.rs
@@ -143,9 +143,6 @@ pub enum ProcessPendingTransactionError {
     #[error("Relayer id {0} / address {1} - Send transaction error: {2}")]
     SendTransactionError(RelayerId, EvmAddress, TransactionQueueSendTransactionError),
 
-    #[error("Transaction could not be sent due to gas calculation error for relayer id {0} / address {1}: tx {2}")]
-    GasCalculationError(RelayerId, EvmAddress, Transaction),
-
     #[error("Relayer id {0} / address {1} - {2}")]
     MovePendingTransactionToInmempoolError(
         RelayerId,

--- a/crates/e2e-tests/src/tests/transactions/gas_estimation.rs
+++ b/crates/e2e-tests/src/tests/transactions/gas_estimation.rs
@@ -102,4 +102,56 @@ impl TestRunner {
 
         Ok(())
     }
+
+    /// run single with:
+    /// RRELAYER_PROVIDERS="raw" make run-test-debug TEST=transaction_gas_estimation_fails
+    /// RRELAYER_PROVIDERS="privy" make run-test-debug TEST=transaction_gas_estimation_fails
+    /// RRELAYER_PROVIDERS="aws_secret_manager" make run-test-debug TEST=transaction_gas_estimation_fails
+    /// RRELAYER_PROVIDERS="aws_kms" make run-test-debug TEST=transaction_gas_estimation_fails
+    /// RRELAYER_PROVIDERS="gcp_secret_manager" make run-test-debug TEST=transaction_gas_estimation_fails
+    /// RRELAYER_PROVIDERS="turnkey" make run-test-debug TEST=transaction_gas_estimation_fails
+    pub async fn transaction_gas_estimation_fails(&self) -> anyhow::Result<()> {
+        info!("Testing recovery after gas estimation failure...");
+        let relayer = self.create_and_fund_relayer("gas-estimation-fails-relayer").await?;
+        info!("Created relayer: {:?}", relayer);
+
+        let balance_before = self
+            .contract_interactor
+            .get_eth_balance(&relayer.address().await?.into_address())
+            .await?;
+
+        let failing_tx_response = self
+            .relayer_client
+            .send_transaction(
+                relayer.id(),
+                &self.config.anvil_accounts[3],
+                (balance_before * alloy::primitives::U256::from(2)).into(),
+                TransactionData::empty(),
+            )
+            .await;
+
+        anyhow::ensure!(
+            failing_tx_response.is_err(),
+            "Transaction above relayer balance should fail gas estimation"
+        );
+
+        let transfer_amount = alloy::primitives::utils::parse_ether("0.1")?;
+        let tx_response = self
+            .relayer_client
+            .send_transaction(
+                relayer.id(),
+                &self.config.anvil_accounts[3],
+                transfer_amount.into(),
+                TransactionData::empty(),
+            )
+            .await?;
+
+        self.wait_for_transaction_completion(&tx_response.0.id).await?;
+
+        info!("[SUCCESS] Gas estimation failure recovery passed:");
+        info!("  - Failing transaction was rejected");
+        info!("  - Subsequent valid transaction completed successfully");
+
+        Ok(())
+    }
 }

--- a/crates/e2e-tests/src/tests/transactions/mod.rs
+++ b/crates/e2e-tests/src/tests/transactions/mod.rs
@@ -107,6 +107,11 @@ impl TestModule for TransactionTests {
                 |runner| Box::pin(runner.transaction_gas_estimation()),
             ),
             TestDefinition::new(
+                "transaction_gas_estimation_fails",
+                "Transaction gas estimation failure recovery",
+                |runner| Box::pin(runner.transaction_gas_estimation_fails()),
+            ),
+            TestDefinition::new(
                 "transaction_gas_price_bumping",
                 "Transaction gas price bumping",
                 |runner| Box::pin(runner.transaction_gas_price_bumping()),

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -10,6 +10,8 @@
 
 ### Bug fixes
 
+- fix: prevent failed gas estimation from leaving transactions stuck in the pending queue
+
 ---
 
 ### Breaking changes


### PR DESCRIPTION
## Summary
- avoid advancing the relayer nonce before preflight gas estimation succeeds
- persist preflight gas estimation failures as FAILED instead of PENDING
- keep pending transactions queued on transient send-time gas calculation/cache misses and retry with existing relayer pacing
- remove the now-unused pending gas calculation error variant

## Verification
- cargo test -p rrelayer_core
- git diff --check

Closes #52