### PR TITLE
fix: sign with the original key on cloned relayers across wallet providers

### DIFF
--- a/crates/core/src/provider/evm_provider.rs
+++ b/crates/core/src/provider/evm_provider.rs
@@ -4,7 +4,8 @@ use crate::relayer::Relayer;
 use crate::wallet::{
     AwsKmsWalletManager, CompositeWalletManager, FireblocksWalletManager, ImportKeyResult,
     MnemonicWalletManager, Pkcs11WalletManager, PrivateKeyWalletManager, PrivyWalletManager,
-    TurnkeyWalletManager, WalletError, WalletManagerTrait,
+    TurnkeyWalletManager, WalletError, WalletManagerChainId, WalletManagerCloneChain,
+    WalletManagerTrait,
 };
 use crate::yaml::{
     AwsKmsSigningProviderConfig, FireblocksSigningProviderConfig, Pkcs11SigningProviderConfig,
@@ -288,9 +289,12 @@ impl EvmProvider {
     }
 
     pub async fn clone_wallet(&self, relayer: &Relayer) -> Result<EvmAddress, WalletError> {
-        self.wallet_manager
-            .create_wallet(relayer.wallet_index(), relayer.wallet_manager_chain_id())
-            .await
+        let chain_id = WalletManagerChainId::Cloned(WalletManagerCloneChain {
+            cloned_from: relayer.chain_id,
+            cloned_to: self.chain_id,
+        });
+
+        self.wallet_manager.create_wallet(relayer.wallet_index(), chain_id).await
     }
 
     pub async fn create_wallet(&self, wallet_index: u32) -> Result<EvmAddress, WalletError> {
@@ -506,5 +510,138 @@ impl EvmProvider {
 
     pub fn supports_blobs(&self) -> bool {
         self.wallet_manager.supports_blobs()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::relayer::RelayerId;
+    use crate::wallet::WalletManagerChainId;
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use tokio::sync::Mutex;
+
+    struct RecordingWalletManager {
+        last_create_chain: Arc<Mutex<Option<(u64, u64)>>>,
+        address: EvmAddress,
+    }
+
+    #[async_trait]
+    impl WalletManagerTrait for RecordingWalletManager {
+        async fn create_wallet(
+            &self,
+            _wallet_index: u32,
+            chain_id: WalletManagerChainId,
+        ) -> Result<EvmAddress, WalletError> {
+            match chain_id {
+                WalletManagerChainId::Cloned(chain) => {
+                    let mut last_create_chain = self.last_create_chain.lock().await;
+                    *last_create_chain = Some((chain.cloned_from.u64(), chain.cloned_to.u64()));
+                }
+                WalletManagerChainId::ChainId(chain_id) => {
+                    let mut last_create_chain = self.last_create_chain.lock().await;
+                    *last_create_chain = Some((chain_id.u64(), chain_id.u64()));
+                }
+            }
+
+            Ok(self.address)
+        }
+
+        async fn get_address(
+            &self,
+            _wallet_index: u32,
+            _chain_id: WalletManagerChainId,
+        ) -> Result<EvmAddress, WalletError> {
+            Ok(self.address)
+        }
+
+        async fn sign_transaction(
+            &self,
+            _wallet_index: u32,
+            _transaction: &TypedTransaction,
+            _chain_id: WalletManagerChainId,
+        ) -> Result<Signature, WalletError> {
+            Err(WalletError::UnsupportedOperation("not used in this test".to_string()))
+        }
+
+        async fn sign_text(
+            &self,
+            _wallet_index: u32,
+            _text: &str,
+            _chain_id: WalletManagerChainId,
+        ) -> Result<Signature, WalletError> {
+            Err(WalletError::UnsupportedOperation("not used in this test".to_string()))
+        }
+
+        async fn sign_typed_data(
+            &self,
+            _wallet_index: u32,
+            _typed_data: &TypedData,
+            _chain_id: WalletManagerChainId,
+        ) -> Result<Signature, WalletError> {
+            Err(WalletError::UnsupportedOperation("not used in this test".to_string()))
+        }
+
+        fn supports_blobs(&self) -> bool {
+            true
+        }
+    }
+
+    struct UnusedGasEstimator;
+
+    #[async_trait]
+    impl BaseGasFeeEstimator for UnusedGasEstimator {
+        async fn get_gas_prices(
+            &self,
+            _chain_id: &ChainId,
+        ) -> Result<GasEstimatorResult, GasEstimatorError> {
+            unreachable!("clone_wallet does not estimate gas")
+        }
+
+        fn is_chain_supported(&self, _chain_id: &ChainId) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn clone_wallet_passes_source_and_destination_chain_ids() {
+        let last_create_chain = Arc::new(Mutex::new(None));
+        let address = EvmAddress::zero();
+        let wallet_manager = Arc::new(RecordingWalletManager {
+            last_create_chain: last_create_chain.clone(),
+            address,
+        });
+
+        let provider = EvmProvider {
+            rpc_clients: Vec::new(),
+            wallet_manager,
+            gas_estimator: Arc::new(UnusedGasEstimator),
+            chain_id: ChainId::new(31337),
+            name: "destination".to_string(),
+            provider_urls: Vec::new(),
+            blocks_every: 250,
+            confirmations: 1,
+            can_clone: true,
+        };
+
+        let source_relayer = Relayer {
+            id: RelayerId::new(),
+            name: "source".to_string(),
+            chain_id: ChainId::new(1),
+            cloned_from_chain_id: None,
+            address,
+            wallet_index: 7,
+            max_gas_price: None,
+            paused: false,
+            eip_1559_enabled: true,
+            created_at: Utc::now(),
+            is_private_key: false,
+        };
+
+        let cloned_address = provider.clone_wallet(&source_relayer).await.unwrap();
+
+        assert_eq!(cloned_address, address);
+        assert_eq!(*last_create_chain.lock().await, Some((1, 31337)));
     }
 }

--- a/crates/core/src/wallet/aws_kms_wallet_manager.rs
+++ b/crates/core/src/wallet/aws_kms_wallet_manager.rs
@@ -27,11 +27,15 @@ pub struct KeyPlan {
     pub tags: Vec<(String, String)>,
 }
 
+/// Signers keyed by (wallet_index, lookup_chain_id, signing_chain_id).
+type SignerCacheKey = (u32, u64, u64);
+type SignerCache = Arc<RwLock<HashMap<SignerCacheKey, AwsSigner>>>;
+
 #[derive(Debug)]
 pub struct AwsKmsWalletManager {
     config: AwsKmsSigningProviderConfig,
     alias: String,
-    signers: Arc<RwLock<HashMap<(u32, u64, u64), AwsSigner>>>,
+    signers: SignerCache,
 }
 
 #[derive(Debug)]

--- a/crates/core/src/wallet/aws_kms_wallet_manager.rs
+++ b/crates/core/src/wallet/aws_kms_wallet_manager.rs
@@ -31,7 +31,7 @@ pub struct KeyPlan {
 pub struct AwsKmsWalletManager {
     config: AwsKmsSigningProviderConfig,
     alias: String,
-    signers: Arc<RwLock<HashMap<(u32, u64), AwsSigner>>>,
+    signers: Arc<RwLock<HashMap<(u32, u64, u64), AwsSigner>>>,
 }
 
 #[derive(Debug)]
@@ -174,7 +174,8 @@ impl AwsKmsWalletManager {
         chain_id: WalletManagerChainId,
     ) -> Result<AwsSigner, WalletError> {
         let lookup_chain_id = chain_id.cloned_from_chain_id_or_default();
-        let cache_key = (wallet_index, lookup_chain_id.u64());
+        let signing_chain_id = chain_id.main();
+        let cache_key = (wallet_index, lookup_chain_id.u64(), signing_chain_id.u64());
 
         {
             let signers = self.signers.read().await;
@@ -197,7 +198,7 @@ impl AwsKmsWalletManager {
         }
 
         let signer =
-            self.initialize_aws_kms_signer(key_id.item(), Some(chain_id.main().u64())).await?;
+            self.initialize_aws_kms_signer(key_id.item(), Some(signing_chain_id.u64())).await?;
 
         {
             let mut signers = self.signers.write().await;

--- a/crates/core/src/wallet/mnemonic_wallet_manager.rs
+++ b/crates/core/src/wallet/mnemonic_wallet_manager.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use tokio::sync::Mutex;
 
 pub struct MnemonicWalletManager {
-    wallets: Mutex<HashMap<u32, PrivateKeySigner>>,
+    wallets: Mutex<HashMap<(u32, u64), PrivateKeySigner>>,
     mnemonic: String,
 }
 
@@ -36,9 +36,10 @@ impl MnemonicWalletManager {
         index: u32,
         chain_id: &ChainId,
     ) -> Result<PrivateKeySigner, LocalSignerError> {
+        let cache_key = (index, chain_id.u64());
         let mut wallets = self.wallets.lock().await;
 
-        if let Some(wallet) = wallets.get(&index) {
+        if let Some(wallet) = wallets.get(&cache_key) {
             Ok(wallet.clone())
         } else {
             let wallet = MnemonicBuilder::<English>::default()
@@ -47,7 +48,7 @@ impl MnemonicWalletManager {
                 .build()?
                 .with_chain_id(Some((*chain_id).into()));
 
-            wallets.insert(index, wallet.clone());
+            wallets.insert(cache_key, wallet.clone());
 
             Ok(wallet)
         }

--- a/crates/core/src/wallet/pkcs11_wallet_manager.rs
+++ b/crates/core/src/wallet/pkcs11_wallet_manager.rs
@@ -409,7 +409,8 @@ impl WalletManagerTrait for Pkcs11WalletManager {
         wallet_index: u32,
         chain_id: WalletManagerChainId,
     ) -> Result<EvmAddress, WalletError> {
-        let address = self.get_public_key(wallet_index, chain_id.main()).await?;
+        let address =
+            self.get_public_key(wallet_index, chain_id.cloned_from_chain_id_or_default()).await?;
         Ok(EvmAddress::from(address))
     }
 
@@ -418,7 +419,8 @@ impl WalletManagerTrait for Pkcs11WalletManager {
         wallet_index: u32,
         chain_id: WalletManagerChainId,
     ) -> Result<EvmAddress, WalletError> {
-        let address = self.get_public_key(wallet_index, chain_id.main()).await?;
+        let address =
+            self.get_public_key(wallet_index, chain_id.cloned_from_chain_id_or_default()).await?;
         Ok(EvmAddress::from(address))
     }
 
@@ -429,7 +431,7 @@ impl WalletManagerTrait for Pkcs11WalletManager {
         chain_id: WalletManagerChainId,
     ) -> Result<Signature, WalletError> {
         let tx_hash = transaction.signature_hash();
-        self.sign_hash(wallet_index, &tx_hash, chain_id.main()).await
+        self.sign_hash(wallet_index, &tx_hash, chain_id.cloned_from_chain_id_or_default()).await
     }
 
     async fn sign_text(
@@ -441,7 +443,7 @@ impl WalletManagerTrait for Pkcs11WalletManager {
         let message = format!("\x19Ethereum Signed Message:\n{}{}", text.len(), text);
         let hash = keccak256(message.as_bytes());
 
-        self.sign_hash(wallet_index, &hash, chain_id.main()).await
+        self.sign_hash(wallet_index, &hash, chain_id.cloned_from_chain_id_or_default()).await
     }
 
     async fn sign_typed_data(
@@ -451,7 +453,7 @@ impl WalletManagerTrait for Pkcs11WalletManager {
         chain_id: WalletManagerChainId,
     ) -> Result<Signature, WalletError> {
         let hash = typed_data.eip712_signing_hash()?;
-        self.sign_hash(wallet_index, &hash, chain_id.main()).await
+        self.sign_hash(wallet_index, &hash, chain_id.cloned_from_chain_id_or_default()).await
     }
 
     fn supports_blobs(&self) -> bool {

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -10,6 +10,11 @@
 
 ### Bug fixes
 
+- fix: pass source and destination chain ids when cloning a relayer so cloned wallets resolve the original key
+- fix: cache AWS KMS signers by lookup and signing chain id so cloned relayers sign with the correct chain id
+- fix: use the source chain id for PKCS#11 key lookups so cloned relayers sign with the original HSM key
+- fix: cache mnemonic signers per chain id so cloning a relayer no longer breaks signing on the source chain
+
 ---
 
 ### Breaking changes


### PR DESCRIPTION
## Summary

Fixes cloned relayers signing with the wrong key or wrong chain id (#38).

- `EvmProvider::clone_wallet` now passes `WalletManagerChainId::Cloned { cloned_from, cloned_to }` (source and destination chain ids) instead of just the source chain id, so wallet managers can resolve the original key while signing for the new chain.
- **AWS KMS**: the signer cache is now keyed by `(wallet_index, lookup_chain, signing_chain)`. Previously a source relayer and its clone shared a cache entry, so the clone could sign with a signer bound to the source chain's EIP-155 chain id.
- **PKCS#11**: all key lookups (create/get address, sign tx/text/typed data) now use the source chain id for cloned relayers, so they sign with the original HSM key (same address) instead of minting a new key on the destination chain.
- **Mnemonic**: the signer cache is now keyed per `(wallet_index, chain_id)`. Previously it was keyed by index alone, so a clone operation could cache a signer stamped with the destination chain id and every subsequent transaction from the source relayer failed with `TransactionChainIdMismatch` until restart.

Also adds a unit test asserting `clone_wallet` propagates the source and destination chain ids, and changelog entries.

## Testing

- `cargo test -p rrelayer_core` — all tests pass, including the new `clone_wallet_passes_source_and_destination_chain_ids`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)