### PR TITLE
feat: Cron Job Transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ rrelayer and all the commands available to you.
 - API Keys: Built-in API keys for relayers to allow you to give access to a system without giving access to every part of the rrelayer
 - Webhooks: Notifications built in get notified of the transaction's status every step of the way or if balances are low.
 - Rate Limiting: Built-in rate limiting allowing you to rate limit user transactions allowance by just updating the rrelayer.yaml
+- Cron Jobs: Schedule recurring contract calls or raw calldata transactions from rrelayer.yaml.
 - Flexibility: No hard constraints on features like you can config how often it bumps gas depending on your need. Maybe a liquidation bot may want to bump every block for example.
 - CLI: rrelayer is CLI first, so you can do everything with the command line tool.
 - Full transactions support: rrelayer can send blob transactions and any kind of EVM transaction.

--- a/crates/cli/src/commands/new.rs
+++ b/crates/cli/src/commands/new.rs
@@ -86,6 +86,7 @@ pub async fn handle_init(path: &Path) -> Result<(), InitError> {
         },
         webhooks: None,
         rate_limits: None,
+        cron_jobs: None,
     };
     fs::write(project_path.join("rrelayer.yaml"), serde_yaml::to_string(&yaml_content)?)?;
 

--- a/crates/core/src/background_tasks/cron_job_task.rs
+++ b/crates/core/src/background_tasks/cron_job_task.rs
@@ -1,0 +1,438 @@
+use std::{sync::Arc, time::Duration};
+
+use alloy::{
+    dyn_abi::{DynSolType, JsonAbiExt},
+    json_abi::Function,
+    primitives::Bytes,
+};
+use chrono::{DateTime, Utc};
+use rand::seq::SliceRandom;
+use tokio::time;
+use tracing::{error, info};
+
+use crate::{
+    postgres::{PostgresClient, PostgresError},
+    relayer::Relayer,
+    shutdown::subscribe_to_shutdown,
+    transaction::{
+        queue_system::{TransactionToSend, TransactionsQueues},
+        types::{TransactionData, TransactionValue},
+    },
+    yaml::{
+        parse_cron_job_interval, AllOrOneOrManyAddresses, CronJobConfig, CronJobTransactionConfig,
+        SetupConfig,
+    },
+};
+
+impl PostgresClient {
+    async fn get_cron_job_last_ran_at(
+        &self,
+        project_name: &str,
+        job_name: &str,
+    ) -> Result<Option<DateTime<Utc>>, PostgresError> {
+        let row = self
+            .query_one_or_none(
+                "
+                    SELECT last_ran_at
+                    FROM relayer.cron_job_state
+                    WHERE project_name = $1
+                    AND job_name = $2;
+                ",
+                &[&project_name, &job_name],
+            )
+            .await?;
+
+        Ok(row.map(|row| row.get("last_ran_at")))
+    }
+
+    async fn mark_cron_job_ran(
+        &self,
+        project_name: &str,
+        job_name: &str,
+        ran_at: DateTime<Utc>,
+    ) -> Result<(), PostgresError> {
+        self.execute(
+            "
+                INSERT INTO relayer.cron_job_state(project_name, job_name, last_ran_at, updated_at)
+                VALUES ($1, $2, $3, NOW())
+                ON CONFLICT (project_name, job_name)
+                DO UPDATE SET last_ran_at = EXCLUDED.last_ran_at, updated_at = NOW();
+            ",
+            &[&project_name, &job_name, &ran_at],
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+pub fn run_cron_job_tasks(
+    config: SetupConfig,
+    postgres_client: Arc<PostgresClient>,
+    transactions_queues: Arc<tokio::sync::Mutex<TransactionsQueues>>,
+) {
+    let cron_jobs = match config.cron_jobs.clone() {
+        Some(cron_jobs) => cron_jobs,
+        None => {
+            info!("Cron jobs disabled - no cron_jobs configuration found");
+            return;
+        }
+    };
+
+    let enabled_jobs: Vec<CronJobConfig> =
+        cron_jobs.into_iter().filter(|cron_job| cron_job.enabled).collect();
+
+    if enabled_jobs.is_empty() {
+        info!("Cron jobs disabled - no enabled cron_jobs found");
+        return;
+    }
+
+    info!("Starting {} cron job background task(s)", enabled_jobs.len());
+
+    for cron_job in enabled_jobs {
+        let postgres_client = postgres_client.clone();
+        let transactions_queues = transactions_queues.clone();
+        let config = config.clone();
+
+        tokio::spawn(async move {
+            run_cron_job(config, cron_job, postgres_client, transactions_queues).await;
+        });
+    }
+}
+
+async fn run_cron_job(
+    config: SetupConfig,
+    cron_job: CronJobConfig,
+    postgres_client: Arc<PostgresClient>,
+    transactions_queues: Arc<tokio::sync::Mutex<TransactionsQueues>>,
+) {
+    let interval_duration = match parse_cron_job_interval(&cron_job.schedule.every) {
+        Ok(duration) => duration,
+        Err(err) => {
+            error!("Cron job {} has invalid interval: {}", cron_job.name, err);
+            return;
+        }
+    };
+
+    let mut shutdown_rx = subscribe_to_shutdown();
+
+    let startup_delay =
+        next_cron_job_delay(&config, &cron_job, &postgres_client, interval_duration).await;
+
+    if wait_for_delay_or_shutdown(startup_delay, &mut shutdown_rx, &cron_job.name).await {
+        return;
+    }
+
+    loop {
+        enqueue_cron_job_transaction(&config, &cron_job, &postgres_client, &transactions_queues)
+            .await;
+
+        if wait_for_delay_or_shutdown(interval_duration, &mut shutdown_rx, &cron_job.name).await {
+            break;
+        }
+    }
+}
+
+async fn next_cron_job_delay(
+    config: &SetupConfig,
+    cron_job: &CronJobConfig,
+    postgres_client: &PostgresClient,
+    interval_duration: Duration,
+) -> Duration {
+    match postgres_client.get_cron_job_last_ran_at(&config.name, &cron_job.name).await {
+        Ok(Some(last_ran_at)) => {
+            let next_run_at = last_ran_at + interval_duration;
+            let now = Utc::now();
+
+            if next_run_at <= now {
+                Duration::ZERO
+            } else {
+                (next_run_at - now).to_std().unwrap_or(Duration::ZERO)
+            }
+        }
+        Ok(None) => {
+            if cron_job.schedule.run_on_startup.unwrap_or(false) {
+                Duration::ZERO
+            } else {
+                // Anchor the schedule now, otherwise a restart before the first run
+                // would reset the initial interval and the job could never fire.
+                if let Err(err) = postgres_client
+                    .mark_cron_job_ran(&config.name, &cron_job.name, Utc::now())
+                    .await
+                {
+                    error!(
+                        "Cron job {} failed to persist schedule anchor: {}",
+                        cron_job.name, err
+                    );
+                }
+
+                interval_duration
+            }
+        }
+        Err(err) => {
+            error!(
+                "Cron job {} failed to read last run state, waiting full interval: {}",
+                cron_job.name, err
+            );
+            interval_duration
+        }
+    }
+}
+
+async fn wait_for_delay_or_shutdown(
+    delay: Duration,
+    shutdown_rx: &mut tokio::sync::broadcast::Receiver<()>,
+    cron_job_name: &str,
+) -> bool {
+    if delay.is_zero() {
+        return false;
+    }
+
+    tokio::select! {
+        _ = time::sleep(delay) => false,
+        _ = shutdown_rx.recv() => {
+            info!("Shutdown signal received, stopping cron job {}", cron_job_name);
+            true
+        }
+    }
+}
+
+async fn enqueue_cron_job_transaction(
+    config: &SetupConfig,
+    cron_job: &CronJobConfig,
+    postgres_client: &PostgresClient,
+    transactions_queues: &Arc<tokio::sync::Mutex<TransactionsQueues>>,
+) {
+    let relayer = match select_cron_job_relayer(config, cron_job, postgres_client).await {
+        Ok(relayer) => relayer,
+        Err(err) => {
+            error!(
+                "Cron job {} could not select relayer on network {}: {}",
+                cron_job.name, cron_job.network, err
+            );
+            return;
+        }
+    };
+
+    let transaction_to_send = match build_transaction_to_send(&cron_job.transaction) {
+        Ok(transaction_to_send) => transaction_to_send,
+        Err(err) => {
+            error!("Cron job {} has invalid transaction: {}", cron_job.name, err);
+            return;
+        }
+    };
+
+    match transactions_queues.lock().await.add_transaction(&relayer.id, &transaction_to_send).await
+    {
+        Ok(transaction) => {
+            if let Err(err) =
+                postgres_client.mark_cron_job_ran(&config.name, &cron_job.name, Utc::now()).await
+            {
+                error!("Cron job {} failed to persist last run state: {}", cron_job.name, err);
+            }
+
+            info!(
+                "Cron job {} queued transaction {} for relayer {}",
+                cron_job.name, transaction.id, relayer.id
+            );
+        }
+        Err(err) => {
+            error!(
+                "Cron job {} failed to queue transaction for relayer {}: {}",
+                cron_job.name, relayer.id, err
+            );
+        }
+    }
+}
+
+async fn select_cron_job_relayer(
+    config: &SetupConfig,
+    cron_job: &CronJobConfig,
+    postgres_client: &PostgresClient,
+) -> Result<Relayer, String> {
+    let network_config = config
+        .networks
+        .iter()
+        .find(|network| network.name == cron_job.network)
+        .ok_or_else(|| format!("network {} is not configured", cron_job.network))?;
+
+    let relayers = postgres_client
+        .get_all_relayers_for_chain(&network_config.chain_id)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    let mut available_relayers: Vec<_> = relayers
+        .into_iter()
+        .filter(|relayer| !relayer.paused)
+        .filter(|relayer| match &cron_job.relayers {
+            AllOrOneOrManyAddresses::All => true,
+            relayers => relayers.contains(&relayer.address),
+        })
+        .filter(|relayer| {
+            validate_cron_job_transaction_permissions(config, cron_job, relayer).is_ok()
+        })
+        .collect();
+
+    let mut rng = rand::thread_rng();
+    available_relayers.shuffle(&mut rng);
+
+    available_relayers.into_iter().next().ok_or_else(|| {
+        format!(
+            "no available relayers found for network {} matching cron job relayers filter and permissions",
+            cron_job.network
+        )
+    })
+}
+
+fn validate_cron_job_transaction_permissions(
+    config: &SetupConfig,
+    cron_job: &CronJobConfig,
+    relayer: &Relayer,
+) -> Result<(), String> {
+    let network_config =
+        match config.networks.iter().find(|network| network.chain_id == relayer.chain_id) {
+            Some(network_config) => network_config,
+            None => return Ok(()),
+        };
+
+    let Some(permissions) = &network_config.permissions else {
+        return Ok(());
+    };
+
+    for permission in permissions {
+        if !permission.relayers.contains(&relayer.address) {
+            continue;
+        }
+
+        if permission.disable_transactions.unwrap_or_default() {
+            return Err("relayer has transactions disabled".to_string());
+        }
+
+        if permission.disable_native_transfer.unwrap_or_default()
+            && cron_job
+                .transaction
+                .value
+                .as_deref()
+                .unwrap_or("0")
+                .parse::<TransactionValue>()
+                .map(|value| !value.is_zero())
+                .unwrap_or(false)
+        {
+            return Err("relayer has native transfers disabled".to_string());
+        }
+
+        if !permission.allowlist.is_empty()
+            && !permission.allowlist.contains(&cron_job.transaction.to)
+        {
+            return Err(format!(
+                "relayer is not allowed to send transactions to {}",
+                cron_job.transaction.to
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn build_transaction_to_send(
+    transaction: &CronJobTransactionConfig,
+) -> Result<TransactionToSend, String> {
+    let value = transaction
+        .value
+        .as_deref()
+        .unwrap_or("0")
+        .parse::<TransactionValue>()
+        .map_err(|err| format!("invalid value: {err}"))?;
+
+    let data = match (&transaction.data, &transaction.contract) {
+        (Some(data), None) => TransactionData::raw_hex(data)?,
+        (None, Some(contract)) => encode_contract_call(&contract.function, &contract.args)?,
+        (None, None) => {
+            return Err("transaction.data or transaction.contract is required".to_string())
+        }
+        (Some(_), Some(_)) => {
+            return Err(
+                "transaction.data and transaction.contract cannot both be defined".to_string()
+            );
+        }
+    };
+
+    Ok(TransactionToSend::new(
+        transaction.to,
+        value,
+        data,
+        transaction.speed.clone(),
+        None,
+        transaction.external_id.clone(),
+    ))
+}
+
+fn encode_contract_call(function: &str, args: &[String]) -> Result<TransactionData, String> {
+    let function = Function::parse(function)
+        .map_err(|err| format!("invalid contract function signature: {err}"))?;
+
+    if function.inputs.len() != args.len() {
+        return Err(format!(
+            "function expects {} arg(s), got {}",
+            function.inputs.len(),
+            args.len()
+        ));
+    }
+
+    let values = function
+        .inputs
+        .iter()
+        .zip(args)
+        .map(|(param, arg)| {
+            let ty = param
+                .ty
+                .parse::<DynSolType>()
+                .map_err(|err| format!("invalid ABI parameter type {}: {err}", param.ty))?;
+
+            ty.coerce_str(arg)
+                .map_err(|err| format!("invalid ABI arg {} for type {}: {err}", arg, param.ty))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    function
+        .abi_encode_input(&values)
+        .map(|encoded| TransactionData::new(Bytes::from(encoded)))
+        .map_err(|err| format!("failed to ABI encode contract call: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_transaction_from_raw_data() {
+        let transaction = CronJobTransactionConfig {
+            to: "0x0000000000000000000000000000000000000001".parse().unwrap(),
+            value: Some("1".to_string()),
+            speed: None,
+            external_id: Some("job-1".to_string()),
+            data: Some("0x1234".to_string()),
+            contract: None,
+        };
+
+        let transaction_to_send = build_transaction_to_send(&transaction).unwrap();
+        assert_eq!(transaction_to_send.to, transaction.to);
+        assert_eq!(transaction_to_send.value, "1".parse::<TransactionValue>().unwrap());
+        assert_eq!(transaction_to_send.data.hex(), "1234");
+        assert_eq!(transaction_to_send.external_id, Some("job-1".to_string()));
+    }
+
+    #[test]
+    fn encodes_contract_call_data() {
+        let data = encode_contract_call(
+            "transfer(address,uint256)",
+            &["0x0000000000000000000000000000000000000001".to_string(), "100".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            data.hex(),
+            "a9059cbb00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000064"
+        );
+    }
+}

--- a/crates/core/src/background_tasks/cron_job_task.rs
+++ b/crates/core/src/background_tasks/cron_job_task.rs
@@ -160,10 +160,7 @@ async fn next_cron_job_delay(
                     .mark_cron_job_ran(&config.name, &cron_job.name, Utc::now())
                     .await
                 {
-                    error!(
-                        "Cron job {} failed to persist schedule anchor: {}",
-                        cron_job.name, err
-                    );
+                    error!("Cron job {} failed to persist schedule anchor: {}", cron_job.name, err);
                 }
 
                 interval_duration

--- a/crates/core/src/background_tasks/cron_job_task.rs
+++ b/crates/core/src/background_tasks/cron_job_task.rs
@@ -261,9 +261,21 @@ async fn select_cron_job_relayer(
         .await
         .map_err(|err| err.to_string())?;
 
+    // Automatic top-up "from" relayers default to internal only and cannot be
+    // used to send normal transactions, matching the API transaction paths.
+    let internal_only_relayers: Vec<_> = config
+        .networks
+        .iter()
+        .filter(|network| network.chain_id == network_config.chain_id)
+        .flat_map(|network| network.automatic_top_up.iter().flatten())
+        .filter(|top_up| top_up.from.relayer.internal_only.unwrap_or(true))
+        .map(|top_up| top_up.from.relayer.address)
+        .collect();
+
     let mut available_relayers: Vec<_> = relayers
         .into_iter()
         .filter(|relayer| !relayer.paused)
+        .filter(|relayer| !internal_only_relayers.contains(&relayer.address))
         .filter(|relayer| match &cron_job.relayers {
             AllOrOneOrManyAddresses::All => true,
             relayers => relayers.contains(&relayer.address),

--- a/crates/core/src/background_tasks/mod.rs
+++ b/crates/core/src/background_tasks/mod.rs
@@ -1,9 +1,11 @@
 mod automatic_top_up_task;
 mod balance_monitor;
+mod cron_job_task;
 mod webhook_manager_task;
 
 use crate::background_tasks::{
-    balance_monitor::balance_monitor, webhook_manager_task::run_webhook_manager_task,
+    balance_monitor::balance_monitor, cron_job_task::run_cron_job_tasks,
+    webhook_manager_task::run_webhook_manager_task,
 };
 use crate::gas::{blob_gas_oracle, gas_oracle, BlobGasOracleCache, GasOracleCache};
 use crate::{
@@ -45,9 +47,11 @@ pub async fn run_background_tasks(
         config.clone(),
         postgres_client.clone(),
         providers.clone(),
-        transactions_queues,
+        transactions_queues.clone(),
         safe_proxy_manager,
     );
+
+    run_cron_job_tasks(config.clone(), postgres_client.clone(), transactions_queues.clone());
 
     let balance_monitor_task =
         balance_monitor(providers.clone(), postgres_client.clone(), webhook_manager.clone());

--- a/crates/core/src/schema/mod.rs
+++ b/crates/core/src/schema/mod.rs
@@ -1,5 +1,6 @@
 use crate::schema::v1_0_1::apply_v1_0_1_schema;
 use crate::schema::v1_0_2::apply_v1_0_2_schema;
+use crate::schema::v1_0_3::apply_v1_0_3_schema;
 use crate::{
     postgres::{PostgresClient, PostgresError},
     schema::v1_0_0::apply_v1_0_0_schema,
@@ -8,12 +9,14 @@ use crate::{
 mod v1_0_0;
 mod v1_0_1;
 mod v1_0_2;
+mod v1_0_3;
 
 /// Applies the database schema to the database.
 pub async fn apply_schema(client: &PostgresClient) -> Result<(), PostgresError> {
     apply_v1_0_0_schema(client).await?;
     apply_v1_0_1_schema(client).await?;
     apply_v1_0_2_schema(client).await?;
+    apply_v1_0_3_schema(client).await?;
 
     Ok(())
 }

--- a/crates/core/src/schema/v1_0_3.rs
+++ b/crates/core/src/schema/v1_0_3.rs
@@ -1,0 +1,18 @@
+use crate::postgres::{PostgresClient, PostgresError};
+
+/// Applies the RRelayer database schema version 1.0.3.
+/// Adds persistent cron job run state so schedules survive process restarts.
+pub async fn apply_v1_0_3_schema(client: &PostgresClient) -> Result<(), PostgresError> {
+    let schema_sql = r#"
+        CREATE TABLE IF NOT EXISTS relayer.cron_job_state (
+            project_name VARCHAR(255) NOT NULL,
+            job_name VARCHAR(255) NOT NULL,
+            last_ran_at TIMESTAMPTZ NOT NULL,
+            updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+            PRIMARY KEY (project_name, job_name)
+        );
+    "#;
+
+    client.batch_execute(schema_sql).await?;
+    Ok(())
+}

--- a/crates/core/src/yaml.rs
+++ b/crates/core/src/yaml.rs
@@ -1,9 +1,10 @@
+use alloy::json_abi::Function;
 use alloy::primitives::utils::{parse_units, ParseUnits};
 use alloy::primitives::U256;
 use regex::{Captures, Regex};
 use serde::de::Visitor;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use std::{env, fmt, fs::File, io::Read, path::PathBuf};
+use std::{env, fmt, fs::File, io::Read, path::PathBuf, time::Duration};
 use thiserror::Error;
 
 use crate::gas::{
@@ -915,6 +916,154 @@ pub struct SafeProxyConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CronJobScheduleConfig {
+    /// Run the job at this interval. Supports s, m, h, d, and w suffixes.
+    pub every: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub run_on_startup: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CronJobContractCallConfig {
+    /// Human-readable Solidity signature, e.g. "transfer(address,uint256)".
+    pub function: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CronJobTransactionConfig {
+    pub to: EvmAddress,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub speed: Option<TransactionSpeed>,
+    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none", default)]
+    pub external_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub contract: Option<CronJobContractCallConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CronJobConfig {
+    pub name: String,
+    #[serde(default = "default_cron_job_enabled")]
+    pub enabled: bool,
+    /// Network name from the networks section.
+    pub network: String,
+    /// Relayer addresses to choose from. Use "*" to allow any relayer on the network.
+    pub relayers: AllOrOneOrManyAddresses,
+    pub schedule: CronJobScheduleConfig,
+    pub transaction: CronJobTransactionConfig,
+}
+
+fn default_cron_job_enabled() -> bool {
+    true
+}
+
+pub fn parse_cron_job_interval(interval: &str) -> Result<Duration, String> {
+    let trimmed = interval.trim();
+    if trimmed.len() < 2 || !trimmed.is_ascii() {
+        return Err("interval must include a positive number and unit".to_string());
+    }
+
+    let (amount, unit) = trimmed.split_at(trimmed.len() - 1);
+    let amount: u64 = amount.parse().map_err(|_| {
+        "interval must include a positive whole number followed by s, m, h, d, or w".to_string()
+    })?;
+
+    if amount == 0 {
+        return Err("interval must be greater than zero".to_string());
+    }
+
+    let seconds = match unit {
+        "s" => amount,
+        "m" => amount * 60,
+        "h" => amount * 60 * 60,
+        "d" => amount * 60 * 60 * 24,
+        "w" => amount * 60 * 60 * 24 * 7,
+        _ => return Err("interval unit must be one of s, m, h, d, or w".to_string()),
+    };
+
+    Ok(Duration::from_secs(seconds))
+}
+
+impl CronJobConfig {
+    fn validate(&self, networks: &[NetworkSetupConfig]) -> Result<(), String> {
+        if self.name.trim().is_empty() {
+            return Err("cron job name cannot be empty".to_string());
+        }
+
+        if self.network.trim().is_empty() {
+            return Err(format!("cron job {} network cannot be empty", self.name));
+        }
+
+        if !networks.iter().any(|network| network.name == self.network) {
+            return Err(format!(
+                "cron job {} references unknown network {}",
+                self.name, self.network
+            ));
+        }
+
+        if self.relayers.is_empty() {
+            return Err(format!("cron job {} relayers cannot be empty", self.name));
+        }
+
+        parse_cron_job_interval(&self.schedule.every)
+            .map_err(|err| format!("cron job {} has invalid schedule.every: {err}", self.name))?;
+
+        if self.transaction.data.is_some() && self.transaction.contract.is_some() {
+            return Err(format!(
+                "cron job {} must define either transaction.data or transaction.contract, not both",
+                self.name
+            ));
+        }
+
+        if self.transaction.data.is_none() && self.transaction.contract.is_none() {
+            return Err(format!(
+                "cron job {} must define transaction.data or transaction.contract",
+                self.name
+            ));
+        }
+
+        if let Some(data) = &self.transaction.data {
+            crate::transaction::types::TransactionData::raw_hex(data).map_err(|err| {
+                format!("cron job {} has invalid transaction.data: {err}", self.name)
+            })?;
+        }
+
+        if let Some(value) = &self.transaction.value {
+            value.parse::<crate::transaction::types::TransactionValue>().map_err(|err| {
+                format!("cron job {} has invalid transaction.value: {err}", self.name)
+            })?;
+        }
+
+        if let Some(contract) = &self.transaction.contract {
+            if contract.function.trim().is_empty() {
+                return Err(format!("cron job {} contract.function cannot be empty", self.name));
+            }
+
+            let function = Function::parse(&contract.function).map_err(|err| {
+                format!("cron job {} has invalid contract.function: {err}", self.name)
+            })?;
+
+            if function.inputs.len() != contract.args.len() {
+                return Err(format!(
+                    "cron job {} contract.function expects {} arg(s), got {}",
+                    self.name,
+                    function.inputs.len(),
+                    contract.args.len()
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SetupConfig {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -929,6 +1078,8 @@ pub struct SetupConfig {
     pub webhooks: Option<Vec<WebhookConfig>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rate_limits: Option<RateLimitConfig>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cron_jobs: Option<Vec<CronJobConfig>>,
 }
 
 fn substitute_env_variables(contents: &str) -> Result<String, regex::Error> {
@@ -968,6 +1119,9 @@ pub enum ReadYamlError {
 
     #[error("Network {0} provider urls not defined")]
     NetworkProviderUrlsNotDefined(String),
+
+    #[error("Cron job yaml bad format: {0}")]
+    CronJobYamlError(String),
 }
 
 /// Reads and parses the RRelayer configuration YAML file.
@@ -1016,5 +1170,79 @@ pub fn read(file_path: &PathBuf, raw_yaml: bool) -> Result<SetupConfig, ReadYaml
         }
     }
 
+    if let Some(cron_jobs) = &config.cron_jobs {
+        let mut cron_job_names = std::collections::HashSet::new();
+        for cron_job in cron_jobs {
+            cron_job.validate(&config.networks).map_err(ReadYamlError::CronJobYamlError)?;
+
+            if !cron_job_names.insert(cron_job.name.as_str()) {
+                return Err(ReadYamlError::CronJobYamlError(format!(
+                    "cron job name {} is used more than once",
+                    cron_job.name
+                )));
+            }
+        }
+    }
+
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_cron_job_intervals() {
+        assert_eq!(parse_cron_job_interval("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_cron_job_interval("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(parse_cron_job_interval("2h").unwrap(), Duration::from_secs(7200));
+        assert_eq!(parse_cron_job_interval("1d").unwrap(), Duration::from_secs(86400));
+        assert_eq!(parse_cron_job_interval("1w").unwrap(), Duration::from_secs(604800));
+    }
+
+    #[test]
+    fn rejects_invalid_cron_job_intervals() {
+        assert!(parse_cron_job_interval("").is_err());
+        assert!(parse_cron_job_interval("0m").is_err());
+        assert!(parse_cron_job_interval("1 month").is_err());
+        assert!(parse_cron_job_interval("10x").is_err());
+        assert!(parse_cron_job_interval("5м").is_err());
+    }
+
+    #[test]
+    fn parses_setup_config_with_cron_jobs() {
+        let yaml = r#"
+name: cron-project
+signing_provider:
+  raw:
+    mnemonic: test test test test test test test test test test test junk
+networks:
+  - name: local
+    chain_id: 31337
+    provider_urls:
+      - http://localhost:8545
+api_config:
+  port: 8000
+  authentication_username: user
+  authentication_password: pass
+cron_jobs:
+  - name: heartbeat
+    network: local
+    relayers: "*"
+    schedule:
+      every: 5m
+      run_on_startup: true
+    transaction:
+      to: "0x0000000000000000000000000000000000000001"
+      contract:
+        function: setNumber(uint256)
+        args:
+          - "42"
+"#;
+
+        let config: SetupConfig = serde_yaml::from_str(yaml).unwrap();
+        let cron_jobs = config.cron_jobs.unwrap();
+        assert_eq!(cron_jobs.len(), 1);
+        assert!(cron_jobs[0].validate(&config.networks).is_ok());
+    }
 }

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -6,6 +6,8 @@
 
 ### Features
 
+- feat: add YAML-driven cron jobs for recurring relayer transactions and contract calls, with persisted last-run state across restarts
+
 ---
 
 ### Bug fixes

--- a/documentation/rrelayer/docs/pages/config/cron-jobs.mdx
+++ b/documentation/rrelayer/docs/pages/config/cron-jobs.mdx
@@ -1,0 +1,83 @@
+# Cron Jobs
+
+`cron_jobs` lets rrelayer enqueue transactions on a schedule from the YAML file. Jobs run inside the relayer process and use the same transaction queue as API-submitted transactions.
+
+## Configuration
+
+```yaml [rrelayer.yaml]
+name: first-rrelayer
+description: 'my first rrelayer'
+api_config:
+  port: 3000
+  authentication_username: ${RRELAYER_AUTH_USERNAME}
+  authentication_password: ${RRELAYER_AUTH_PASSWORD}
+signing_provider:
+  aws_kms:
+    region: 'eu-west-1'
+networks:
+  - name: sepolia_ethereum
+    chain_id: 11155111
+    provider_urls:
+      - https://sepolia.gateway.tenderly.co
+    block_explorer_url: https://sepolia.etherscan.io
+    max_gas_price_multiplier: 4
+cron_jobs: // [!code focus]
+  - name: refresh-price // [!code focus]
+    enabled: true // [!code focus]
+    network: sepolia_ethereum // [!code focus]
+    relayers: '*' // [!code focus]
+    schedule: // [!code focus]
+      every: 15m // [!code focus]
+      run_on_startup: false // [!code focus]
+    transaction: // [!code focus]
+      to: '0x0000000000000000000000000000000000000001' // [!code focus]
+      value: '0' // [!code focus]
+      speed: FAST // [!code focus]
+      externalId: refresh-price // [!code focus]
+      contract: // [!code focus]
+        function: updatePrice(uint256,address) // [!code focus]
+        args: // [!code focus]
+          - '100000000' // [!code focus]
+          - '0x0000000000000000000000000000000000000002' // [!code focus]
+```
+
+## Relayers
+
+`relayers` is required. Set it to `'*'` to choose any non-paused relayer on the configured `network`, or set it to a single relayer address or list of relayer addresses to restrict which relayers can be used. Relayers that are not allowed to send the transaction because of network [permissions](/config/networks/permissions) are skipped automatically.
+
+```yaml [rrelayer.yaml]
+cron_jobs:
+  - name: restricted-refresh
+    network: sepolia_ethereum
+    relayers: '0x0000000000000000000000000000000000000003'
+    schedule:
+      every: 15m
+    transaction:
+      to: '0x0000000000000000000000000000000000000001'
+      contract:
+        function: updatePrice(uint256)
+        args:
+          - '100000000'
+```
+
+## Schedule
+
+The `every` interval supports `s`, `m`, `h`, `d`, and `w` suffixes. rrelayer stores when each cron job last queued a transaction, keyed by project name and job name, so restarting the server does not immediately rerun a job that ran recently.
+
+Set `run_on_startup: true` to run the job immediately the first time it is seen, instead of waiting a full interval.
+
+## Transaction
+
+Use `transaction.contract` with a human-readable Solidity function signature and args to have rrelayer ABI encode the calldata for you, or for pre-encoded calldata use `transaction.data` instead:
+
+```yaml [rrelayer.yaml]
+cron_jobs:
+  - name: raw-call
+    network: sepolia_ethereum
+    relayers: '*'
+    schedule:
+      every: 1h
+    transaction:
+      to: '0x0000000000000000000000000000000000000001'
+      data: '0x1234'
+```

--- a/documentation/rrelayer/docs/pages/config/index.mdx
+++ b/documentation/rrelayer/docs/pages/config/index.mdx
@@ -92,6 +92,22 @@ rate_limits:
       interval: 'minute'
       transactions: 3
       signing_operations: 3
+cron_jobs:
+  - name: heartbeat
+    enabled: true
+    network: sepolia_ethereum
+    relayers: '*'
+    schedule:
+      every: 5m
+      run_on_startup: true
+    transaction:
+      to: '0x0000000000000000000000000000000000000001'
+      speed: FAST
+      externalId: heartbeat
+      contract:
+        function: setNumber(uint256)
+        args:
+          - '42'
 ```
 
 ### Environment Variables

--- a/documentation/rrelayer/vocs.config.tsx
+++ b/documentation/rrelayer/vocs.config.tsx
@@ -188,6 +188,7 @@ export default defineConfig({
         },
         { text: 'Webhooks', link: '/config/webhooks' },
         { text: 'Rate limits', link: '/config/rate-limits' },
+        { text: 'Cron jobs', link: '/config/cron-jobs' },
       ],
     },
     {


### PR DESCRIPTION
Closes #3

Adds a `cron_jobs` section to `rrelayer.yaml` that enqueues transactions on a fixed interval from inside the relayer process, using the same transaction queue as API-submitted transactions.

## Config

```yaml
cron_jobs:
  - name: refresh-price
    network: sepolia_ethereum
    relayers: '*'
    schedule:
      every: 15m
      run_on_startup: false
    transaction:
      to: '0x0000000000000000000000000000000000000001'
      speed: FAST
      contract:
        function: updatePrice(uint256,address)
        args:
          - '100000000'
          - '0x0000000000000000000000000000000000000002'
```

## Details

- `schedule.every` supports `s`/`m`/`h`/`d`/`w` suffixes, with optional `run_on_startup` to fire immediately the first time a job is seen.
- `transaction.contract` ABI-encodes a human-readable function signature and args; `transaction.data` takes pre-encoded calldata instead.
- `relayers` is `'*'`, a single address, or a list — a random non-paused relayer matching the filter is picked each run, and relayers blocked by network permissions (`disable_transactions`, `allowlist`, `disable_native_transfer`) are skipped automatically.
- Last-run state is persisted per project/job in a new `relayer.cron_job_state` table (schema v1.0.3), and an anchor timestamp is written when a job is first seen, so schedules survive restarts instead of resetting the interval.
- Config is validated at startup: unknown networks, duplicate job names, invalid intervals, values, calldata, or function signatures fail config loading with a clear error.
- Docs: new [Cron Jobs](documentation/rrelayer/docs/pages/config/cron-jobs.mdx) config page wired into the sidebar, plus README and changelog entries.

## Testing

- Unit tests for interval parsing (including rejection of zero, malformed, and non-ASCII input), YAML parsing/validation, transaction building, and ABI encoding.
- `cargo test -p rrelayer_core` and `cargo check --workspace` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)