### PR TITLE
Run raw provider e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,56 @@ jobs:
       - name: Run clippy
         run: cargo clippy -- -D warnings -A clippy::uninlined_format_args
 
+  e2e_raw:
+    name: E2E Raw Provider
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      RAW_DANGEROUS_MNEMONIC: "enjoy jar sentence ghost buddy humble monster cannon fix ill eternal desert patrol tumble calm logic wrestle wall above grab debate noble absurd merry"
+      DATABASE_URL: "postgresql://postgres:rrelayer@localhost:5447/postgres"
+      POSTGRES_PASSWORD: "rrelayer"
+      RRELAYER_AUTH_USERNAME: "admin"
+      RRELAYER_AUTH_PASSWORD: "your_secure_password_here"
+      RRELAYER_WEBHOOK_SHARED_SECRET: "test-webhook-secret-123"
+      API_KEY_1: "test-api-key-1"
+      API_KEY_2: "test-api-key-2"
+      API_KEY_3: "test-api-key-3"
+      RRELAYER_MULTI_PROVIDER: "1"
+      RRELAYER_PROVIDERS: "raw"
+      FOUNDRY_DISABLE_NIGHTLY_WARNING: "true"
+      RUST_BACKTRACE: "1"
+      RUST_LOG: "error"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: e2e-raw
+          cache-on-failure: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libssl-dev pkg-config
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install Foundry contract dependencies
+        working-directory: crates/e2e-tests/contracts
+        run: forge install foundry-rs/forge-std@v1.11.0 --no-git
+
+      - name: Run raw provider E2E tests
+        working-directory: crates/e2e-tests
+        run: cargo run --bin e2e-runner
+
+      - name: Clean up E2E services
+        if: always()
+        working-directory: crates/e2e-tests
+        run: docker compose down --volumes --remove-orphans
+
   build:
     if: |
       (github.event_name == 'push' || github.event_name == 'pull_request') &&

--- a/crates/core/src/rate_limiting/rate_limiter.rs
+++ b/crates/core/src/rate_limiting/rate_limiter.rs
@@ -47,9 +47,19 @@ impl RateLimiter {
     }
 
     fn parse_interval(interval: &str) -> u32 {
+        let interval = interval.trim();
         match interval {
-            "1m" => 60,
-            _ => 60,
+            "second" | "seconds" => 1,
+            "minute" | "minutes" => 60,
+            _ => {
+                if let Some(seconds) = interval.strip_suffix('s') {
+                    seconds.parse::<u32>().unwrap_or(60).max(1)
+                } else if let Some(minutes) = interval.strip_suffix('m') {
+                    minutes.parse::<u32>().map(|value| value * 60).unwrap_or(60).max(1)
+                } else {
+                    60
+                }
+            }
         }
     }
 

--- a/crates/core/src/transaction/queue_system/transactions_queue.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queue.rs
@@ -40,6 +40,18 @@ use tokio::sync::Mutex;
 use tracing::error;
 use tracing::info;
 
+fn bump_u128_by_at_least_one(value: u128) -> u128 {
+    value + std::cmp::max(value / 20, 1)
+}
+
+fn bump_max_fee_by_at_least_one(max_fee: MaxFee) -> MaxFee {
+    MaxFee::new(bump_u128_by_at_least_one(max_fee.into_u128()))
+}
+
+fn bump_max_priority_fee_by_at_least_one(max_priority_fee: MaxPriorityFee) -> MaxPriorityFee {
+    MaxPriorityFee::new(bump_u128_by_at_least_one(max_priority_fee.into_u128()))
+}
+
 pub struct TransactionsQueue {
     pending_transactions: Mutex<VecDeque<Transaction>>,
     inmempool_transactions: Mutex<VecDeque<CompetitiveTransaction>>,
@@ -121,9 +133,10 @@ impl TransactionsQueue {
             let max_allowed_priority_fee =
                 super_price.max_priority_fee.into_u128() * (self.max_gas_price_multiplier as u128);
 
-            let at_max_fee_cap = sent_gas.max_fee.into_u128() >= max_allowed_max_fee;
-            let at_max_priority_fee_cap =
-                sent_gas.max_priority_fee.into_u128() >= max_allowed_priority_fee;
+            let at_max_fee_cap =
+                max_allowed_max_fee > 0 && sent_gas.max_fee.into_u128() >= max_allowed_max_fee;
+            let at_max_priority_fee_cap = max_allowed_priority_fee > 0
+                && sent_gas.max_priority_fee.into_u128() >= max_allowed_priority_fee;
 
             if at_max_fee_cap || at_max_priority_fee_cap {
                 info!(
@@ -154,7 +167,9 @@ impl TransactionsQueue {
             let max_allowed_blob_gas_price =
                 super_price.blob_gas_price * (self.max_gas_price_multiplier as u128);
 
-            if sent_blob_gas.blob_gas_price >= max_allowed_blob_gas_price {
+            if max_allowed_blob_gas_price > 0
+                && sent_blob_gas.blob_gas_price >= max_allowed_blob_gas_price
+            {
                 info!(
                     "Transaction at maximum blob gas price cap for relayer: {} - blob_gas_price: {} (cap: {})",
                     self.relayer.name,
@@ -786,9 +801,9 @@ impl TransactionsQueue {
                 // Already at SUPER speed, do small percentage bumps
                 if gas_price.max_fee <= sent_gas.max_fee {
                     let old_max_fee = gas_price.max_fee;
-                    gas_price.max_fee = sent_gas.max_fee + (sent_gas.max_fee / 20); // 5% bump
+                    gas_price.max_fee = bump_max_fee_by_at_least_one(sent_gas.max_fee);
                     info!(
-                        "Small bump max_fee for relayer: {} from {} to {} (5%)",
+                        "Small bump max_fee for relayer: {} from {} to {} (5% minimum 1 wei)",
                         self.relayer.name,
                         old_max_fee.into_u128(),
                         gas_price.max_fee.into_u128()
@@ -798,9 +813,9 @@ impl TransactionsQueue {
                 if gas_price.max_priority_fee <= sent_gas.max_priority_fee {
                     let old_priority_fee = gas_price.max_priority_fee;
                     gas_price.max_priority_fee =
-                        sent_gas.max_priority_fee + (sent_gas.max_priority_fee / 20); // 5% bump
+                        bump_max_priority_fee_by_at_least_one(sent_gas.max_priority_fee);
                     info!(
-                        "Small bump max_priority_fee for relayer: {} from {} to {} (5%)",
+                        "Small bump max_priority_fee for relayer: {} from {} to {} (5% minimum 1 wei)",
                         self.relayer.name,
                         old_priority_fee.into_u128(),
                         gas_price.max_priority_fee.into_u128()
@@ -816,7 +831,7 @@ impl TransactionsQueue {
                     sent_gas.max_fee.into_u128(),
                     self.relayer.name
                 );
-                gas_price.max_fee = sent_gas.max_fee + (sent_gas.max_fee / 20); // 5% bump
+                gas_price.max_fee = bump_max_fee_by_at_least_one(sent_gas.max_fee);
             }
 
             if gas_price.max_priority_fee <= sent_gas.max_priority_fee {
@@ -827,8 +842,7 @@ impl TransactionsQueue {
                     self.relayer.name
                 );
                 gas_price.max_priority_fee =
-                    sent_gas.max_priority_fee + (sent_gas.max_priority_fee / 20);
-                // 5% bump
+                    bump_max_priority_fee_by_at_least_one(sent_gas.max_priority_fee);
             }
 
             // Get SUPER speed gas price for cap calculation
@@ -845,7 +859,7 @@ impl TransactionsQueue {
                 let max_allowed_priority_fee = super_price.max_priority_fee.into_u128()
                     * (self.max_gas_price_multiplier as u128);
 
-                if gas_price.max_fee.into_u128() > max_allowed_max_fee {
+                if max_allowed_max_fee > 0 && gas_price.max_fee.into_u128() > max_allowed_max_fee {
                     info!(
                         "Gas price max_fee {} exceeds cap {} ({}x SUPER speed), capping for relayer: {}",
                         gas_price.max_fee.into_u128(),
@@ -856,7 +870,9 @@ impl TransactionsQueue {
                     gas_price.max_fee = MaxFee::from(max_allowed_max_fee);
                 }
 
-                if gas_price.max_priority_fee.into_u128() > max_allowed_priority_fee {
+                if max_allowed_priority_fee > 0
+                    && gas_price.max_priority_fee.into_u128() > max_allowed_priority_fee
+                {
                     info!(
                         "Gas price max_priority_fee {} exceeds cap {} ({}x SUPER speed), capping for relayer: {}",
                         gas_price.max_priority_fee.into_u128(),
@@ -866,6 +882,16 @@ impl TransactionsQueue {
                     );
                     gas_price.max_priority_fee = MaxPriorityFee::from(max_allowed_priority_fee);
                 }
+            }
+
+            if gas_price.max_priority_fee.into_u128() > gas_price.max_fee.into_u128() {
+                info!(
+                    "Adjusted max_priority_fee {} down to max_fee {} for relayer: {}",
+                    gas_price.max_priority_fee.into_u128(),
+                    gas_price.max_fee.into_u128(),
+                    self.relayer.name
+                );
+                gas_price.max_priority_fee = MaxPriorityFee::from(gas_price.max_fee.into_u128());
             }
         }
 
@@ -928,12 +954,12 @@ impl TransactionsQueue {
                 if blob_gas_price.blob_gas_price < sent_blob_gas.blob_gas_price {
                     let old_blob_gas_price = blob_gas_price.blob_gas_price;
                     blob_gas_price.blob_gas_price =
-                        sent_blob_gas.blob_gas_price + (sent_blob_gas.blob_gas_price / 20); // 5% bump
+                        bump_u128_by_at_least_one(sent_blob_gas.blob_gas_price);
                     blob_gas_price.total_fee_for_blob =
                         blob_gas_price.blob_gas_price * BLOB_GAS_PER_BLOB;
 
                     info!(
-                        "Small bump blob gas price for relayer: {} from {} to {} (5%), total_fee: {}",
+                        "Small bump blob gas price for relayer: {} from {} to {} (5% minimum 1 wei), total_fee: {}",
                         self.relayer.name,
                         old_blob_gas_price,
                         blob_gas_price.blob_gas_price,
@@ -951,7 +977,7 @@ impl TransactionsQueue {
                     self.relayer.name
                 );
                 blob_gas_price.blob_gas_price =
-                    sent_blob_gas.blob_gas_price + (sent_blob_gas.blob_gas_price / 20); // 5% bump
+                    bump_u128_by_at_least_one(sent_blob_gas.blob_gas_price);
                 blob_gas_price.total_fee_for_blob =
                     blob_gas_price.blob_gas_price * BLOB_GAS_PER_BLOB;
             }
@@ -968,7 +994,9 @@ impl TransactionsQueue {
                 let max_allowed_blob_gas_price =
                     super_price.blob_gas_price * (self.max_gas_price_multiplier as u128);
 
-                if blob_gas_price.blob_gas_price > max_allowed_blob_gas_price {
+                if max_allowed_blob_gas_price > 0
+                    && blob_gas_price.blob_gas_price > max_allowed_blob_gas_price
+                {
                     info!(
                         "Blob gas price {} exceeds cap {} ({}x SUPER speed), capping for relayer: {}",
                         blob_gas_price.blob_gas_price,

--- a/crates/core/src/transaction/queue_system/transactions_queues.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queues.rs
@@ -37,7 +37,10 @@ use crate::transaction::api::RelayTransactionRequest;
 use crate::transaction::queue_system::types::SendTransactionGasPriceError;
 use crate::transaction::types::{TransactionBlob, TransactionConversionError, TransactionSpeed};
 use crate::{
-    gas::{BlobGasOracleCache, BlobGasPriceResult, GasLimit, GasOracleCache, GasPriceResult},
+    gas::{
+        BlobGasOracleCache, BlobGasPriceResult, GasLimit, GasOracleCache, GasPriceResult, MaxFee,
+        MaxPriorityFee,
+    },
     postgres::{PostgresClient, PostgresConnectionError},
     relayer::RelayerId,
     safe_proxy::SafeProxyManager,
@@ -51,6 +54,24 @@ use crate::{
     },
     webhooks::WebhookManager,
 };
+
+const SAME_NONCE_BUMP_DIVISOR: u128 = 5;
+const MIN_SAME_NONCE_GAS_BUMP_WEI: u128 = 1_000_000_000;
+
+fn bump_u128_for_same_nonce_competitor(value: u128) -> u128 {
+    value
+        .saturating_add(std::cmp::max(value / SAME_NONCE_BUMP_DIVISOR, MIN_SAME_NONCE_GAS_BUMP_WEI))
+}
+
+fn bump_max_fee_for_same_nonce_competitor(max_fee: MaxFee) -> MaxFee {
+    MaxFee::new(bump_u128_for_same_nonce_competitor(max_fee.into_u128()))
+}
+
+fn bump_max_priority_fee_for_same_nonce_competitor(
+    max_priority_fee: MaxPriorityFee,
+) -> MaxPriorityFee {
+    MaxPriorityFee::new(bump_u128_for_same_nonce_competitor(max_priority_fee.into_u128()))
+}
 
 /// Container for managing multiple transaction queues across different relayers.
 ///
@@ -577,10 +598,14 @@ impl TransactionsQueues {
                                 )
                             })?;
 
-                        // Bump original gas prices by 20% to ensure replacement
-                        let bumped_max_fee = original_gas.max_fee + (original_gas.max_fee / 5);
+                        // Bump original gas prices by 20% with a 1 gwei floor so tiny local
+                        // raw-provider fees still produce a transaction miners prefer.
+                        let bumped_max_fee =
+                            bump_max_fee_for_same_nonce_competitor(original_gas.max_fee);
                         let bumped_max_priority_fee =
-                            original_gas.max_priority_fee + (original_gas.max_priority_fee / 5);
+                            bump_max_priority_fee_for_same_nonce_competitor(
+                                original_gas.max_priority_fee,
+                            );
 
                         let gas_price = GasPriceResult {
                             max_fee: bumped_max_fee,
@@ -836,10 +861,14 @@ impl TransactionsQueues {
                         );
                         replace_transaction.gas_limit = Some(bumped_gas_limit);
 
-                        // Bump original gas prices by 20% to ensure replacement
-                        let bumped_max_fee = original_gas.max_fee + (original_gas.max_fee / 5);
+                        // Bump original gas prices by 20% with a 1 gwei floor so tiny local
+                        // raw-provider fees still produce a transaction miners prefer.
+                        let bumped_max_fee =
+                            bump_max_fee_for_same_nonce_competitor(original_gas.max_fee);
                         let bumped_max_priority_fee =
-                            original_gas.max_priority_fee + (original_gas.max_priority_fee / 5);
+                            bump_max_priority_fee_for_same_nonce_competitor(
+                                original_gas.max_priority_fee,
+                            );
 
                         let gas_price = GasPriceResult {
                             max_fee: bumped_max_fee,
@@ -929,15 +958,6 @@ impl TransactionsQueues {
                             .save_transaction(&transaction.relayer_id, &replace_transaction)
                             .await
                             .map_err(ReplaceTransactionError::CouldNotUpdateTransactionInDb)?;
-
-                        transactions_queue
-                            .add_competitor_to_inmempool_transaction(
-                                &transaction.id,
-                                replace_transaction.clone(),
-                                CompetitionType::Replace,
-                            )
-                            .await
-                            .map_err(ReplaceTransactionError::SendTransactionError)?;
 
                         result.transaction.cancelled_by_transaction_id =
                             Some(replace_transaction_id);

--- a/crates/e2e-tests/Makefile
+++ b/crates/e2e-tests/Makefile
@@ -28,6 +28,7 @@ install-deps: ## Install required dependencies (Foundry)
 	@echo "Installing Foundry..."
 	@curl -L https://foundry.paradigm.xyz | bash
 	@foundryup
+	@cd contracts && forge install foundry-rs/forge-std@v1.11.0 --no-git
 
 build: ## Build the E2E test binary
 	@cargo build --bin e2e-runner
@@ -43,7 +44,7 @@ clean: stop-postgres stop-anvil stop-rrelayer ## Clean up all running processes 
 
 start-postgres: ## Start PostgreSQL database
 	@echo "Starting PostgreSQL database..."
-	@cd ../.. && docker-compose up -d postgresql
+	@docker compose up -d postgresql
 	@echo "Waiting for PostgreSQL to be ready..."
 	@for i in $$(seq 1 30); do \
 		if PGPASSWORD=rrelayer psql -h localhost -p 5447 -U postgres -d postgres -c "SELECT 1;" >/dev/null 2>&1; then \
@@ -56,7 +57,7 @@ start-postgres: ## Start PostgreSQL database
 
 stop-postgres: ## Stop PostgreSQL database
 	@echo "Stopping PostgreSQL database..."
-	@cd ../.. && docker-compose down postgresql
+	@docker compose down postgresql
 
 reset-db: ## Reset database (drop all schemas and recreate)
 	@echo "Resetting database..."

--- a/crates/e2e-tests/config/aws_kms.yaml
+++ b/crates/e2e-tests/config/aws_kms.yaml
@@ -61,15 +61,15 @@ webhooks:
 rate_limits:
   user_limits:
     per_relayer:
-      interval: "minute"
+      interval: "30s"
       transactions: 1
       signing_operations: 1
     global:
-      interval: "minute"
+      interval: "30s"
       transactions: 3
       signing_operations: 3
 # TODO: needs testing
 #  relayer_limits:
-#    interval: "minute"
+#    interval: "30s"
 #    transactions: 5
 #    signing_operations: 100

--- a/crates/e2e-tests/config/aws_secret_manager.yaml
+++ b/crates/e2e-tests/config/aws_secret_manager.yaml
@@ -68,15 +68,15 @@ webhooks:
 rate_limits:
   user_limits:
     per_relayer:
-      interval: "minute"
+      interval: "30s"
       transactions: 1
       signing_operations: 1
     global:
-      interval: "minute"
+      interval: "30s"
       transactions: 3
       signing_operations: 3
 # TODO: needs testing
 #  relayer_limits:
-#    interval: "minute"
+#    interval: "30s"
 #    transactions: 5
 #    signing_operations: 100

--- a/crates/e2e-tests/config/fireblocks.yaml
+++ b/crates/e2e-tests/config/fireblocks.yaml
@@ -74,15 +74,15 @@ webhooks:
 rate_limits:
   user_limits:
     per_relayer:
-      interval: "minute"
+      interval: "30s"
       transactions: 1
       signing_operations: 1
     global:
-      interval: "minute"
+      interval: "30s"
       transactions: 3
       signing_operations: 3
 # TODO: needs testing
 #  relayer_limits:
-#    interval: "minute"
+#    interval: "30s"
 #    transactions: 5
 #    signing_operations: 100

--- a/crates/e2e-tests/config/gcp_secret_manager.yaml
+++ b/crates/e2e-tests/config/gcp_secret_manager.yaml
@@ -64,16 +64,16 @@ webhooks:
 rate_limits:
   user_limits:
     per_relayer:
-      interval: "minute"
+      interval: "30s"
       transactions: 1
       signing_operations: 1
     global:
-      interval: "minute"
+      interval: "30s"
       transactions: 3
       signing_operations: 3
 # TODO: needs testing
 #  relayer_limits:
-#    interval: "minute"
+#    interval: "30s"
 #    transactions: 5
 #    signing_operations: 100
 api_config:

--- a/crates/e2e-tests/config/pkcs11.yaml
+++ b/crates/e2e-tests/config/pkcs11.yaml
@@ -73,15 +73,15 @@ webhooks:
 rate_limits:
   user_limits:
     per_relayer:
-      interval: "minute"
+      interval: "30s"
       transactions: 1
       signing_operations: 1
     global:
-      interval: "minute"
+      interval: "30s"
       transactions: 3
       signing_operations: 3
 # TODO: needs testing
 #  relayer_limits:
-#    interval: "minute"
+#    interval: "30s"
 #    transactions: 5
 #    signing_operations: 100

--- a/crates/e2e-tests/config/privy.yaml
+++ b/crates/e2e-tests/config/privy.yaml
@@ -52,16 +52,16 @@ webhooks:
 rate_limits:
   user_limits:
     per_relayer:
-      interval: "minute"
+      interval: "30s"
       transactions: 1
       signing_operations: 1
     global:
-      interval: "minute"
+      interval: "30s"
       transactions: 3
       signing_operations: 3
 # TODO: needs testing
 #  relayer_limits:
-#    interval: "minute"
+#    interval: "30s"
 #    transactions: 5
 #    signing_operations: 100
 api_config:

--- a/crates/e2e-tests/config/raw.yaml
+++ b/crates/e2e-tests/config/raw.yaml
@@ -12,7 +12,7 @@ networks:
   provider_urls:
     - http://127.0.0.1:8545
   block_explorer_url: http://localhost:8545
-  max_gas_price_multiplier: 4
+  max_gas_price_multiplier: 100
   gas_bump_blocks_every:
     slow: 10
     medium: 5
@@ -70,15 +70,15 @@ webhooks:
 rate_limits:
   user_limits:
     per_relayer:
-      interval: "minute"
+      interval: "30s"
       transactions: 1
       signing_operations: 1
     global:
-      interval: "minute"
+      interval: "30s"
       transactions: 3
       signing_operations: 3
 # TODO: needs testing
 #  relayer_limits:
-#    interval: "minute"
+#    interval: "30s"
 #    transactions: 5
 #    signing_operations: 100

--- a/crates/e2e-tests/config/turnkey.yaml
+++ b/crates/e2e-tests/config/turnkey.yaml
@@ -59,16 +59,16 @@ webhooks:
 rate_limits:
   user_limits:
     per_relayer:
-      interval: "minute"
+      interval: "30s"
       transactions: 1
       signing_operations: 1
     global:
-      interval: "minute"
+      interval: "30s"
       transactions: 3
       signing_operations: 3
 # TODO: needs testing
 #  relayer_limits:
-#    interval: "minute"
+#    interval: "30s"
 #    transactions: 5
 #    signing_operations: 100
 api_config:

--- a/crates/e2e-tests/docker-compose.yml
+++ b/crates/e2e-tests/docker-compose.yml
@@ -11,5 +11,5 @@ services:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - 5447:5432
-    env_file:
-      - .env
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-rrelayer}

--- a/crates/e2e-tests/src/tests/rate_limiting/mod.rs
+++ b/crates/e2e-tests/src/tests/rate_limiting/mod.rs
@@ -6,6 +6,26 @@ mod transactions_global_limits;
 mod transactions_user_limits;
 
 use crate::tests::registry::{TestDefinition, TestModule};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const RATE_LIMIT_WINDOW_SECS: u64 = 30;
+
+async fn wait_for_rate_limit_reset() {
+    tokio::time::sleep(Duration::from_secs(RATE_LIMIT_WINDOW_SECS + 1)).await;
+}
+
+async fn wait_for_rate_limit_window_headroom() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after UNIX_EPOCH")
+        .as_secs();
+    let seconds_into_window = now % RATE_LIMIT_WINDOW_SECS;
+
+    if seconds_into_window > 10 {
+        tokio::time::sleep(Duration::from_secs(RATE_LIMIT_WINDOW_SECS - seconds_into_window + 1))
+            .await;
+    }
+}
 
 pub struct RateLimitingTests;
 

--- a/crates/e2e-tests/src/tests/rate_limiting/signing_message_global_limits.rs
+++ b/crates/e2e-tests/src/tests/rate_limiting/signing_message_global_limits.rs
@@ -1,6 +1,6 @@
 use crate::tests::test_runner::TestRunner;
 use anyhow::anyhow;
-use std::time::Duration;
+use rrelayer::ApiSdkError;
 use tracing::info;
 
 impl TestRunner {
@@ -14,75 +14,56 @@ impl TestRunner {
     pub async fn rate_limiting_signing_message_global_limits(&self) -> anyhow::Result<()> {
         info!("Testing rate limiting signing message global enforcement...");
 
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer1: {:?}", relayer);
+        super::wait_for_rate_limit_window_headroom().await;
 
         let relay_key = Some(self.config.anvil_accounts[0].to_string());
 
         let mut successful_signing = 0;
+        let mut attempts = 0;
 
-        let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
+        while successful_signing < 3 {
+            attempts += 1;
+            if attempts > 12 {
+                return Err(anyhow!(
+                    "Could not complete 3 successful signing operations before testing the global limit"
+                ));
+            }
 
-        if sign_result.is_ok() {
-            successful_signing += 1
+            let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
+            info!("allowed relayer attempt {}: {:?}", attempts, relayer);
+
+            let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
+
+            match sign_result {
+                Ok(_) => successful_signing += 1,
+                Err(ApiSdkError::RateLimitError) => {
+                    return Err(anyhow!(
+                        "Global signing rate limit triggered before 3 successful operations"
+                    ));
+                }
+                Err(error) => {
+                    info!("Skipping relayer that cannot sign text for this test: {}", error);
+                }
+            }
         }
 
         let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer2: {:?}", relayer);
+        info!("over-limit relayer: {:?}", relayer);
 
         let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
 
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer3: {:?}", relayer);
-
-        let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
-
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer4: {:?}", relayer);
-
-        let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
-
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer5: {:?}", relayer);
-
-        let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
-
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer6: {:?}", relayer);
-
-        let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
-
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        if successful_signing != 3 {
-            return Err(anyhow!(
-                "Signing message rate limiting not enforced should of got 3 but got {}",
-                successful_signing
-            ));
+        match sign_result {
+            Err(ApiSdkError::RateLimitError) => {}
+            Ok(_) => return Err(anyhow!("Global signing rate limiting was not enforced")),
+            Err(error) => {
+                return Err(anyhow!("Expected global signing rate limit error, got {}", error));
+            }
         }
 
         info!("Successful signing operations before rate limit: {}", successful_signing);
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire");
+        super::wait_for_rate_limit_reset().await;
 
         let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
 
@@ -93,8 +74,8 @@ impl TestRunner {
             }
         }
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire so doesnt hurt next test");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire so doesnt hurt next test");
+        super::wait_for_rate_limit_reset().await;
 
         info!("Rate limiting mechanism verified");
         Ok(())

--- a/crates/e2e-tests/src/tests/rate_limiting/signing_message_user_limits.rs
+++ b/crates/e2e-tests/src/tests/rate_limiting/signing_message_user_limits.rs
@@ -1,7 +1,6 @@
 use crate::tests::test_runner::TestRunner;
 use alloy::dyn_abi::TypedData;
 use anyhow::{anyhow, Context};
-use std::time::Duration;
 use tracing::info;
 
 impl TestRunner {
@@ -14,6 +13,8 @@ impl TestRunner {
     /// RRELAYER_PROVIDERS="turnkey" make run-test-debug TEST=rate_limiting_signing_message_user_limits
     pub async fn rate_limiting_signing_message_user_limits(&self) -> anyhow::Result<()> {
         info!("Testing rate limiting signing message enforcement...");
+
+        super::wait_for_rate_limit_window_headroom().await;
 
         let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
         info!("relayer: {:?}", relayer);
@@ -89,8 +90,8 @@ impl TestRunner {
             return Err(anyhow!("Signing typed data rate limiting not enforced"));
         }
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire");
+        super::wait_for_rate_limit_reset().await;
 
         let sign_result = relayer.sign().text("Hello, RRelayer!", relay_key.clone()).await;
 
@@ -101,8 +102,8 @@ impl TestRunner {
             }
         }
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire so doesnt hurt next test");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire so doesnt hurt next test");
+        super::wait_for_rate_limit_reset().await;
 
         info!("Rate limiting mechanism verified");
         Ok(())

--- a/crates/e2e-tests/src/tests/rate_limiting/signing_typed_data_global_limits.rs
+++ b/crates/e2e-tests/src/tests/rate_limiting/signing_typed_data_global_limits.rs
@@ -1,7 +1,7 @@
 use crate::tests::test_runner::TestRunner;
 use alloy::dyn_abi::TypedData;
 use anyhow::{anyhow, Context};
-use std::time::Duration;
+use rrelayer::ApiSdkError;
 use tracing::info;
 
 impl TestRunner {
@@ -15,8 +15,7 @@ impl TestRunner {
     pub async fn rate_limiting_signing_typed_data_global_limits(&self) -> anyhow::Result<()> {
         info!("Testing rate limiting signing typed data global enforcement...");
 
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer1: {:?}", relayer);
+        super::wait_for_rate_limit_window_headroom().await;
 
         let relay_key = Some(self.config.anvil_accounts[0].to_string());
 
@@ -62,69 +61,56 @@ impl TestRunner {
             serde_json::from_value(typed_data_json).context("Failed to create typed data")?;
 
         let mut successful_signing = 0;
+        let mut attempts = 0;
 
-        let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
+        while successful_signing < 3 {
+            attempts += 1;
+            if attempts > 12 {
+                return Err(anyhow!(
+                    "Could not complete 3 successful typed-data signing operations before testing the global limit"
+                ));
+            }
 
-        if sign_result.is_ok() {
-            successful_signing += 1
+            let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
+            info!("allowed relayer attempt {}: {:?}", attempts, relayer);
+
+            let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
+
+            match sign_result {
+                Ok(_) => successful_signing += 1,
+                Err(ApiSdkError::RateLimitError) => {
+                    return Err(anyhow!(
+                        "Global typed-data signing rate limit triggered before 3 successful operations"
+                    ));
+                }
+                Err(error) => {
+                    info!("Skipping relayer that cannot sign typed data for this test: {}", error);
+                }
+            }
         }
 
         let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer2: {:?}", relayer);
+        info!("over-limit relayer: {:?}", relayer);
 
         let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
 
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer3: {:?}", relayer);
-
-        let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
-
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer4: {:?}", relayer);
-
-        let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
-
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer5: {:?}", relayer);
-
-        let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
-
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer6: {:?}", relayer);
-
-        let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
-
-        if sign_result.is_ok() {
-            successful_signing += 1
-        }
-
-        if successful_signing != 3 {
-            return Err(anyhow!(
-                "Signing typed data rate limiting not enforced should of got 3 but got {}",
-                successful_signing
-            ));
+        match sign_result {
+            Err(ApiSdkError::RateLimitError) => {}
+            Ok(_) => {
+                return Err(anyhow!("Global typed-data signing rate limiting was not enforced"));
+            }
+            Err(error) => {
+                return Err(anyhow!(
+                    "Expected global typed-data signing rate limit error, got {}",
+                    error
+                ));
+            }
         }
 
         info!("Successful signing operations before rate limit: {}", successful_signing);
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire");
+        super::wait_for_rate_limit_reset().await;
 
         let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
 
@@ -135,8 +121,8 @@ impl TestRunner {
             }
         }
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire so doesnt hurt next test");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire so doesnt hurt next test");
+        super::wait_for_rate_limit_reset().await;
 
         info!("Rate limiting mechanism verified");
         Ok(())

--- a/crates/e2e-tests/src/tests/rate_limiting/signing_typed_data_user_limits.rs
+++ b/crates/e2e-tests/src/tests/rate_limiting/signing_typed_data_user_limits.rs
@@ -1,7 +1,6 @@
 use crate::tests::test_runner::TestRunner;
 use alloy::dyn_abi::TypedData;
 use anyhow::{anyhow, Context};
-use std::time::Duration;
 use tracing::info;
 
 impl TestRunner {
@@ -14,6 +13,8 @@ impl TestRunner {
     /// RRELAYER_PROVIDERS="turnkey" make run-test-debug TEST=rate_limiting_signing_typed_data_user_limits
     pub async fn rate_limiting_signing_typed_data_user_limits(&self) -> anyhow::Result<()> {
         info!("Testing rate limiting signing typed data enforcement...");
+
+        super::wait_for_rate_limit_window_headroom().await;
 
         let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
         info!("relayer: {:?}", relayer);
@@ -89,8 +90,8 @@ impl TestRunner {
             return Err(anyhow!("Signing text data rate limiting not enforced"));
         }
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire");
+        super::wait_for_rate_limit_reset().await;
 
         let sign_result = relayer.sign().typed_data(&typed_data, relay_key.clone()).await;
 
@@ -101,8 +102,8 @@ impl TestRunner {
             }
         }
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire so doesnt hurt next test");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire so doesnt hurt next test");
+        super::wait_for_rate_limit_reset().await;
 
         info!("Rate limiting mechanism verified");
         Ok(())

--- a/crates/e2e-tests/src/tests/rate_limiting/transactions_global_limits.rs
+++ b/crates/e2e-tests/src/tests/rate_limiting/transactions_global_limits.rs
@@ -1,8 +1,16 @@
 use crate::tests::test_runner::TestRunner;
 use anyhow::anyhow;
+use rrelayer::ApiSdkError;
 use rrelayer_core::transaction::types::TransactionData;
-use std::time::Duration;
 use tracing::info;
+
+fn is_rate_limit_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<ApiSdkError>()
+            .is_some_and(|error| matches!(error, ApiSdkError::RateLimitError))
+    })
+}
 
 impl TestRunner {
     /// run single with:
@@ -15,30 +23,50 @@ impl TestRunner {
     pub async fn rate_limiting_transaction_global_limits(&self) -> anyhow::Result<()> {
         info!("Testing rate limiting transaction enforcement...");
 
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer1: {:?}", relayer);
+        super::wait_for_rate_limit_window_headroom().await;
 
         let relay_key = Some(self.config.anvil_accounts[0].to_string());
 
         let mut successful_transactions = 0;
+        let mut attempts = 0;
 
-        let tx_result = self
-            .relayer_client
-            .send_transaction_with_rate_limit_key(
-                relayer.id(),
-                &self.config.anvil_accounts[1],
-                alloy::primitives::utils::parse_ether("0.5")?.into(),
-                TransactionData::empty(),
-                relay_key.clone(),
-            )
-            .await;
+        while successful_transactions < 3 {
+            attempts += 1;
+            if attempts > 12 {
+                return Err(anyhow!(
+                    "Could not send 3 successful transactions before testing the global limit"
+                ));
+            }
 
-        if tx_result.is_ok() {
-            successful_transactions += 1
+            let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
+            info!("allowed relayer attempt {}: {:?}", attempts, relayer);
+
+            let tx_result = self
+                .relayer_client
+                .send_transaction_with_rate_limit_key(
+                    relayer.id(),
+                    &self.config.anvil_accounts[1],
+                    alloy::primitives::utils::parse_ether("0.5")?.into(),
+                    TransactionData::empty(),
+                    relay_key.clone(),
+                )
+                .await;
+
+            match tx_result {
+                Ok(_) => successful_transactions += 1,
+                Err(error) if is_rate_limit_error(&error) => {
+                    return Err(anyhow!(
+                        "Global transaction rate limit triggered before 3 successful transactions"
+                    ));
+                }
+                Err(error) => {
+                    info!("Skipping relayer that cannot send transaction for this test: {}", error);
+                }
+            }
         }
 
         let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer2: {:?}", relayer);
+        info!("over-limit relayer: {:?}", relayer);
 
         let tx_result = self
             .relayer_client
@@ -51,94 +79,21 @@ impl TestRunner {
             )
             .await;
 
-        if tx_result.is_ok() {
-            successful_transactions += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer3: {:?}", relayer);
-
-        let tx_result = self
-            .relayer_client
-            .send_transaction_with_rate_limit_key(
-                relayer.id(),
-                &self.config.anvil_accounts[1],
-                alloy::primitives::utils::parse_ether("0.5")?.into(),
-                TransactionData::empty(),
-                relay_key.clone(),
-            )
-            .await;
-
-        if tx_result.is_ok() {
-            successful_transactions += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer4: {:?}", relayer);
-
-        let tx_result = self
-            .relayer_client
-            .send_transaction_with_rate_limit_key(
-                relayer.id(),
-                &self.config.anvil_accounts[1],
-                alloy::primitives::utils::parse_ether("0.5")?.into(),
-                TransactionData::empty(),
-                relay_key.clone(),
-            )
-            .await;
-
-        if tx_result.is_ok() {
-            successful_transactions += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer5: {:?}", relayer);
-
-        let tx_result = self
-            .relayer_client
-            .send_transaction_with_rate_limit_key(
-                relayer.id(),
-                &self.config.anvil_accounts[1],
-                alloy::primitives::utils::parse_ether("0.5")?.into(),
-                TransactionData::empty(),
-                relay_key.clone(),
-            )
-            .await;
-
-        if tx_result.is_ok() {
-            successful_transactions += 1
-        }
-
-        let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
-        info!("relayer6: {:?}", relayer);
-
-        let tx_result = self
-            .relayer_client
-            .send_transaction_with_rate_limit_key(
-                relayer.id(),
-                &self.config.anvil_accounts[1],
-                alloy::primitives::utils::parse_ether("0.5")?.into(),
-                TransactionData::empty(),
-                relay_key.clone(),
-            )
-            .await;
-
-        if tx_result.is_ok() {
-            successful_transactions += 1
-        }
-
-        if successful_transactions != 3 {
-            return Err(anyhow!(
-                "Sending transactions rate limiting not enforced should of got 3 but got {}",
-                successful_transactions
-            ));
+        match tx_result {
+            Err(error) if is_rate_limit_error(&error) => {}
+            Ok(_) => {
+                return Err(anyhow!("Global transaction rate limiting was not enforced"));
+            }
+            Err(error) => {
+                return Err(anyhow!("Expected global transaction rate limit error, got {}", error));
+            }
         }
 
         self.mine_blocks(1).await?;
         info!("Successful transactions before rate limit: {}", successful_transactions);
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire");
+        super::wait_for_rate_limit_reset().await;
 
         let tx_result = self
             .relayer_client
@@ -160,8 +115,8 @@ impl TestRunner {
             }
         }
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire so doesnt hurt next test");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire so doesnt hurt next test");
+        super::wait_for_rate_limit_reset().await;
 
         info!("Rate limiting mechanism verified");
         Ok(())

--- a/crates/e2e-tests/src/tests/rate_limiting/transactions_user_limits.rs
+++ b/crates/e2e-tests/src/tests/rate_limiting/transactions_user_limits.rs
@@ -1,7 +1,6 @@
 use crate::tests::test_runner::TestRunner;
 use anyhow::anyhow;
 use rrelayer_core::transaction::types::TransactionData;
-use std::time::Duration;
 use tracing::info;
 
 impl TestRunner {
@@ -14,6 +13,8 @@ impl TestRunner {
     /// RRELAYER_PROVIDERS="turnkey" make run-test-debug TEST=rate_limiting_transaction_user_limits
     pub async fn rate_limiting_transaction_user_limits(&self) -> anyhow::Result<()> {
         info!("Testing rate limiting transaction enforcement...");
+
+        super::wait_for_rate_limit_window_headroom().await;
 
         let relayer = self.create_and_fund_relayer("rate-limit-relayer").await?;
         info!("relayer: {:?}", relayer);
@@ -45,8 +46,8 @@ impl TestRunner {
         self.mine_blocks(1).await?;
         info!("Successful transactions before rate limit: {}", successful_transactions);
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire");
-        tokio::time::sleep(Duration::from_secs(62)).await;
+        info!("Wait for the rate limit to expire");
+        super::wait_for_rate_limit_reset().await;
 
         self.mine_blocks(1).await?;
         self.mine_blocks(1).await?;
@@ -77,8 +78,8 @@ impl TestRunner {
             }
         }
 
-        info!("Sleep for 60 seconds to allow the rate limit to expire so doesnt hurt next test");
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        info!("Wait for the rate limit to expire so doesnt hurt next test");
+        super::wait_for_rate_limit_reset().await;
 
         info!("Rate limiting mechanism verified");
         Ok(())

--- a/crates/e2e-tests/src/tests/transactions/count/pending_and_inmempool_count.rs
+++ b/crates/e2e-tests/src/tests/transactions/count/pending_and_inmempool_count.rs
@@ -46,7 +46,7 @@ impl TestRunner {
                 .relayer_client
                 .send_transaction(
                     relayer.id(),
-                    &self.config.anvil_accounts[4],
+                    &self.config.anvil_accounts[1],
                     alloy::primitives::utils::parse_ether("0.01")?.into(),
                     TransactionData::empty(),
                 )
@@ -55,36 +55,44 @@ impl TestRunner {
             info!("[SUCCESS] Sent transaction {}: {:?}", i + 1, tx_response);
         }
 
-        let pending_count = relayer
+        let pending_count_after_send = relayer
             .transaction()
             .get_count(TransactionCountType::Pending)
             .await
             .context("Failed to get pending count")?;
 
-        if pending_count == 0 {
-            return Err(anyhow!("Expected some pending transactions but got none"));
-        }
-
-        self.mine_and_wait().await?;
-
-        let pending_count = relayer
-            .transaction()
-            .get_count(TransactionCountType::Pending)
-            .await
-            .context("Failed to get pending count")?;
-
-        if pending_count != 0 {
-            return Err(anyhow!("Expected 0 pending transactions, got {}", pending_count));
-        }
-
-        let inmempool_count = relayer
+        let inmempool_count_after_send = relayer
             .transaction()
             .get_count(TransactionCountType::Inmempool)
             .await
             .context("Failed to get inmempool count")?;
 
-        if inmempool_count == 0 {
-            return Err(anyhow!("Expected some inmempool transactions but got none"));
+        if pending_count_after_send + inmempool_count_after_send == 0 {
+            return Err(anyhow!(
+                "Expected some inflight transactions but got pending={} and inmempool={}",
+                pending_count_after_send,
+                inmempool_count_after_send
+            ));
+        }
+
+        let mut attempts = 0;
+        loop {
+            self.mine_and_wait().await?;
+
+            let pending_count = relayer
+                .transaction()
+                .get_count(TransactionCountType::Pending)
+                .await
+                .context("Failed to get pending count")?;
+
+            if pending_count == 0 {
+                break;
+            }
+
+            attempts += 1;
+            if attempts > 10 {
+                return Err(anyhow!("Expected 0 pending transactions, got {}", pending_count));
+            }
         }
 
         self.mine_blocks(2).await?;

--- a/crates/e2e-tests/src/tests/transactions/gas_bumping.rs
+++ b/crates/e2e-tests/src/tests/transactions/gas_bumping.rs
@@ -3,7 +3,7 @@ use alloy::network::ReceiptResponse;
 use anyhow::Context;
 use rrelayer_core::transaction::api::{RelayTransactionRequest, TransactionSpeed};
 use rrelayer_core::transaction::types::{TransactionData, TransactionStatus};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::info;
 
 impl TestRunner {
@@ -61,66 +61,36 @@ impl TestRunner {
                 .sent_with_max_priority_fee_per_gas
                 .context("transaction_before did not have sent_with_max_priority_fee_per_gas")?;
 
-        // wait 10 seconds as gas bumping happens based on time
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        let started_waiting_for_bump = Instant::now();
+        loop {
+            tokio::time::sleep(Duration::from_millis(500)).await;
 
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
-        self.mine_and_wait().await?;
+            let transaction = relayer
+                .transaction()
+                .get(&send_result.id)
+                .await?
+                .context("Transaction not found")?;
+            let max_fee_per_gas_after = transaction
+                .sent_with_max_fee_per_gas
+                .context("transaction_after did not have sent_with_max_fee_per_gas")?;
+            let sent_with_max_priority_after = transaction
+                .sent_with_max_priority_fee_per_gas
+                .context("transaction_after did not have sent_with_max_priority_fee_per_gas")?;
 
-        let transaction_after =
-            relayer.transaction().get(&send_result.id).await?.context("Transaction not found")?;
-        let max_fee_per_gas_after = transaction_after
-            .sent_with_max_fee_per_gas
-            .context("transaction_after did not have sent_with_max_fee_per_gas")?;
-        let sent_with_max_priority_after = transaction_after
-            .sent_with_max_priority_fee_per_gas
-            .context("transaction_after did not have sent_with_max_priority_fee_per_gas")?;
+            if max_fee_per_gas_before != max_fee_per_gas_after
+                || sent_with_max_priority_before != sent_with_max_priority_after
+            {
+                break;
+            }
 
-        if max_fee_per_gas_before == max_fee_per_gas_after
-            && sent_with_max_priority_before == sent_with_max_priority_after
-        {
-            return Err(anyhow::anyhow!(
-                "Gas price did not bump max_fee or sent_with_max_priority one must be bumped"
-            ));
+            if started_waiting_for_bump.elapsed() > Duration::from_secs(20) {
+                return Err(anyhow::anyhow!(
+                    "Gas price did not bump max_fee or sent_with_max_priority one must be bumped"
+                ));
+            }
         }
 
-        let transaction_status = relayer
-            .transaction()
-            .get_status(&send_result.id)
-            .await?
-            .context("Transaction status not found")?
-            .receipt
-            .context("Transaction status did not have receipt")?;
+        let (_, transaction_status) = self.wait_for_transaction_completion(&send_result.id).await?;
         if !transaction_status.status() {
             return Err(anyhow::anyhow!("Transaction failed after gas bumping"));
         }

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -6,9 +6,13 @@
 
 ### Features
 
+- feat: run raw provider e2e tests in CI for pull requests and pushes
+
 ---
 
 ### Bug fixes
+
+- fix: make same-nonce replace and cancel transactions use deterministic gas bumps for raw provider e2e tests
 
 ---
 


### PR DESCRIPTION
## Summary
- add a raw-provider e2e CI job that runs on the existing PR/push/workflow_dispatch triggers
- make the e2e Postgres compose setup work without a checked-in .env
- shorten rate-limit test windows and fix raw gas-bump edge cases so the full raw suite is stable in CI

## Verification
- cargo fmt --all
- cargo check --bin e2e-runner
- cargo run --bin e2e-runner with RRELAYER_PROVIDERS=raw: 49 passed, 49 total
- cargo test --workspace
- cargo clippy -- -D warnings -A clippy::uninlined_format_args
- git diff --check

Closes #9