### PR TITLE
fix: handle queued transaction expiry before broadcast

### DIFF
--- a/crates/core/src/provider/evm_provider.rs
+++ b/crates/core/src/provider/evm_provider.rs
@@ -375,15 +375,18 @@ impl EvmProvider {
         transaction: TypedTransaction,
     ) -> Result<TransactionHash, SendTransactionError> {
         let signature = self
-            .wallet_manager
-            .sign_transaction(
-                relayer.wallet_index(),
-                &transaction,
-                relayer.wallet_manager_chain_id(),
-            )
+            .sign_transaction(relayer, &transaction)
             .await
             .map_err(|e| SendTransactionError::InternalError(e.to_string()))?;
 
+        self.send_signed_transaction(transaction, signature).await
+    }
+
+    pub async fn send_signed_transaction(
+        &self,
+        transaction: TypedTransaction,
+        signature: Signature,
+    ) -> Result<TransactionHash, SendTransactionError> {
         let tx_envelope = match transaction {
             TypedTransaction::Legacy(tx) => TxEnvelope::Legacy(tx.into_signed(signature)),
             TypedTransaction::Eip2930(tx) => TxEnvelope::Eip2930(tx.into_signed(signature)),

--- a/crates/core/src/transaction/db/write.rs
+++ b/crates/core/src/transaction/db/write.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     transaction::types::{
         Transaction, TransactionData, TransactionHash, TransactionId, TransactionNonce,
-        TransactionStatus, TransactionValue,
+        TransactionSpeed, TransactionStatus, TransactionValue,
     },
 };
 use alloy::network::AnyTransactionReceipt;
@@ -188,6 +188,8 @@ impl PostgresClient {
         &mut self,
         transaction_id: &TransactionId,
         to: &EvmAddress,
+        speed: &TransactionSpeed,
+        gas_limit: &GasLimit,
     ) -> Result<(), PostgresError> {
         let mut conn = self.pool.get().await?;
         let trans = conn.transaction().await.map_err(PostgresError::PgError)?;
@@ -198,10 +200,20 @@ impl PostgresClient {
                     UPDATE relayer.transaction
                     SET \"to\" = $2,
                         value = $3,
-                        data = $4
+                        data = $4,
+                        blobs = NULL,
+                        gas_limit = $5,
+                        speed = $6
                     WHERE id = $1;
                 ",
-                &[&transaction_id, &to, &TransactionValue::zero(), &TransactionData::empty()],
+                &[
+                    &transaction_id,
+                    &to,
+                    &TransactionValue::zero(),
+                    &TransactionData::empty(),
+                    gas_limit,
+                    speed,
+                ],
             )
             .await
             .map_err(PostgresError::PgError)?;
@@ -216,14 +228,21 @@ impl PostgresClient {
                         sent_max_fee_per_gas, gas_price, external_id
                     )
                     SELECT
-                        id, relayer_id, $2, \"from\", nonce, chain_id, $4, $3, blobs, gas_limit,
-                        speed, status, expires_at, queued_at, sent_at, mined_at, confirmed_at,
+                        id, relayer_id, $2, \"from\", nonce, chain_id, $4, $3, NULL, $5,
+                        $6, status, expires_at, queued_at, sent_at, mined_at, confirmed_at,
                         failed_at, failed_reason, hash, sent_max_priority_fee_per_gas,
                         sent_max_fee_per_gas, gas_price, external_id
                     FROM relayer.transaction
                     WHERE id = $1;
                 ",
-                &[&transaction_id, &to, &TransactionValue::zero(), &TransactionData::empty()],
+                &[
+                    &transaction_id,
+                    &to,
+                    &TransactionValue::zero(),
+                    &TransactionData::empty(),
+                    gas_limit,
+                    speed,
+                ],
             )
             .await
             .map_err(PostgresError::PgError)?;

--- a/crates/core/src/transaction/queue_system/transactions_queue.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queue.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     network::ChainId,
     postgres::PostgresClient,
-    provider::EvmProvider,
+    provider::{EvmProvider, SendTransactionError},
     relayer::{Relayer, RelayerId},
     safe_proxy::SafeProxyManager,
     shared::common_types::EvmAddress,
@@ -237,6 +237,7 @@ impl TransactionsQueue {
 
     pub async fn move_pending_to_inmempool(
         &mut self,
+        transaction: &Transaction,
         transaction_sent: &TransactionSentWithRelayer,
     ) -> Result<(), MovePendingTransactionToInmempoolError> {
         info!(
@@ -247,8 +248,9 @@ impl TransactionsQueue {
         let mut transactions = self.pending_transactions.lock().await;
         let item = transactions.front().cloned();
 
-        if let Some(transaction) = item {
-            if transaction.id == transaction_sent.id {
+        if let Some(queued_transaction) = item {
+            if queued_transaction.id == transaction_sent.id && transaction.id == transaction_sent.id
+            {
                 let mut inmempool_transactions = self.inmempool_transactions.lock().await;
                 let updated_transaction = Transaction {
                     known_transaction_hash: Some(transaction_sent.hash),
@@ -260,7 +262,7 @@ impl TransactionsQueue {
                     sent_with_gas: Some(transaction_sent.sent_with_gas.clone()),
                     sent_with_blob_gas: transaction_sent.sent_with_blob_gas.clone(),
                     sent_at: Some(Utc::now()),
-                    ..transaction
+                    ..transaction.clone()
                 };
                 inmempool_transactions.push_back(CompetitiveTransaction::new(updated_transaction));
 
@@ -270,12 +272,12 @@ impl TransactionsQueue {
                 Ok(())
             } else {
                 info!("Transaction ID mismatch when moving to inmempool for relayer: {}. Expected: {}, Found: {}",
-                    self.relayer.name, transaction_sent.id, transaction.id);
+                    self.relayer.name, transaction_sent.id, queued_transaction.id);
                 Err(MovePendingTransactionToInmempoolError::TransactionIdDoesNotMatch(
                     self.relayer.id,
                     self.relayer.address,
                     transaction_sent.clone(),
-                    transaction.clone(),
+                    queued_transaction.clone(),
                 ))
             }
         } else {
@@ -409,12 +411,15 @@ impl TransactionsQueue {
                     "Updating inmempool transaction {} with no-op details for relayer: {}",
                     transaction_id, self.relayer.name
                 );
-                transaction.known_transaction_hash = Some(transaction_sent.hash);
-                transaction.to = self.relay_address();
+                transaction.to = self.relayer.address;
                 transaction.value = TransactionValue::zero();
                 transaction.data = TransactionData::empty();
+                transaction.blobs = None;
+                transaction.gas_limit = Some(GasLimit::new(21_000));
                 transaction.is_noop = true;
                 transaction.speed = TransactionSpeed::FAST;
+                transaction.sent_with_blob_gas = None;
+                transaction.known_transaction_hash = Some(transaction_sent.hash);
                 transaction.sent_at = Some(Utc::now());
             }
         }
@@ -479,16 +484,16 @@ impl TransactionsQueue {
 
         if let Some(comp_tx) = item {
             if comp_tx.get_transaction_by_id(id).is_some() {
-                let transaction_status: TransactionStatus;
+                let receipt_transaction_status: TransactionStatus;
 
                 if receipt.status() {
-                    transaction_status = TransactionStatus::MINED;
+                    receipt_transaction_status = TransactionStatus::MINED;
                     info!(
                         "Transaction {} successfully mined for relayer: {}",
                         id, self.relayer.name
                     );
                 } else {
-                    transaction_status = TransactionStatus::FAILED;
+                    receipt_transaction_status = TransactionStatus::FAILED;
                     info!("Transaction {} failed on-chain for relayer: {}", id, self.relayer.name);
                 }
 
@@ -504,8 +509,23 @@ impl TransactionsQueue {
                         TransactionStatus::DROPPED
                     };
 
+                    // is_noop is derived as to == from when rehydrating from the database,
+                    // so also require the noop shape (zero value, empty data) to avoid
+                    // misclassifying a genuine user self-send as expired after a restart
+                    let winner_status = if receipt.status()
+                        && comp_tx.competitive.is_none()
+                        && comp_tx.original.is_noop
+                        && comp_tx.original.value.is_zero()
+                        && comp_tx.original.data == TransactionData::empty()
+                        && Self::has_expired(&comp_tx.original)
+                    {
+                        TransactionStatus::EXPIRED
+                    } else {
+                        receipt_transaction_status
+                    };
+
                     let winner = Transaction {
-                        status: transaction_status,
+                        status: winner_status,
                         mined_at: Some(Utc::now()),
                         cancelled_by_transaction_id: None,
                         ..comp_tx.original
@@ -537,7 +557,7 @@ impl TransactionsQueue {
                     };
 
                     let winner = Transaction {
-                        status: transaction_status,
+                        status: receipt_transaction_status,
                         mined_at: Some(Utc::now()),
                         ..competitor
                     };
@@ -552,8 +572,13 @@ impl TransactionsQueue {
                     ));
                 };
 
-                let mut mining_transactions = self.mined_transactions.lock().await;
-                mining_transactions.insert(winner_transaction.id, winner_transaction.clone());
+                let mined_count = if winner_transaction.status == TransactionStatus::MINED {
+                    let mut mining_transactions = self.mined_transactions.lock().await;
+                    mining_transactions.insert(winner_transaction.id, winner_transaction.clone());
+                    mining_transactions.len()
+                } else {
+                    self.mined_transactions.lock().await.len()
+                };
 
                 // Log competition resolution but don't put loser transactions in mined queue
                 // since they weren't actually mined - they were cancelled/dropped
@@ -563,7 +588,7 @@ impl TransactionsQueue {
                         "Competition resolved for relayer {} - Winner: {} ({}), Loser: {} ({})",
                         self.relayer.name,
                         winner_transaction.id,
-                        transaction_status,
+                        winner_transaction.status,
                         loser.id,
                         loser_status
                     );
@@ -576,11 +601,11 @@ impl TransactionsQueue {
 
                 transactions.pop_front();
                 info!("Successfully moved transaction {} to mined status for relayer: {}. Inmempool: {}, Mined: {}",
-                    id, self.relayer.name, transactions.len(), mining_transactions.len());
+                    id, self.relayer.name, transactions.len(), mined_count);
 
                 Ok(CompetitionResolutionResult {
+                    winner_status: winner_transaction.status,
                     winner: winner_transaction,
-                    winner_status: transaction_status,
                     loser: loser_for_result,
                 })
             } else {
@@ -735,6 +760,21 @@ impl TransactionsQueue {
             );
         }
         in_range
+    }
+
+    pub fn has_expired(transaction: &Transaction) -> bool {
+        transaction.expires_at < Utc::now()
+    }
+
+    pub fn transaction_to_noop(&self, transaction: &mut Transaction) {
+        transaction.to = self.relay_address();
+        transaction.value = TransactionValue::zero();
+        transaction.data = TransactionData::empty();
+        transaction.blobs = None;
+        transaction.gas_limit = Some(GasLimit::new(21_000));
+        transaction.is_noop = true;
+        transaction.speed = TransactionSpeed::FAST;
+        transaction.sent_with_blob_gas = None;
     }
 
     pub async fn compute_gas_price_for_transaction(
@@ -1070,6 +1110,8 @@ impl TransactionsQueue {
         db: &mut PostgresClient,
         transaction: &mut Transaction,
     ) -> Result<TransactionSentWithRelayer, TransactionQueueSendTransactionError> {
+        let was_previously_sent = transaction.sent_with_gas.is_some();
+
         info!(
             "Preparing to send transaction {} for relayer: {} with speed {:?}",
             transaction.id, self.relayer.name, transaction.speed
@@ -1092,10 +1134,14 @@ impl TransactionsQueue {
             return Err(TransactionQueueSendTransactionError::GasPriceTooHigh);
         }
 
-        let (final_to, final_data) = if let Some(safe_address) = self
-            .safe_proxy_manager
-            .get_safe_proxy_for_relayer(&self.relayer.address, transaction.chain_id)
-        {
+        let safe_proxy_address = if transaction.is_noop {
+            None
+        } else {
+            self.safe_proxy_manager
+                .get_safe_proxy_for_relayer(&self.relayer.address, transaction.chain_id)
+        };
+
+        let (final_to, final_data) = if let Some(safe_address) = safe_proxy_address {
             info!(
                 "Routing transaction {} through safe proxy {} for relayer: {}",
                 transaction.id, safe_address, self.relayer.name
@@ -1163,11 +1209,7 @@ impl TransactionsQueue {
 
         // If using safe proxy, the transaction value should be 0 because the ETH transfer
         // amount is encoded in the execTransaction call data, not in the transaction value
-        if self
-            .safe_proxy_manager
-            .get_safe_proxy_for_relayer(&self.relayer.address, transaction.chain_id)
-            .is_some()
-        {
+        if safe_proxy_address.is_some() {
             working_transaction.value = TransactionValue::zero();
         }
 
@@ -1224,11 +1266,7 @@ impl TransactionsQueue {
                 .map_err(TransactionQueueSendTransactionError::TransactionEstimateGasError)?
         };
 
-        if self
-            .safe_proxy_manager
-            .get_safe_proxy_for_relayer(&self.relayer.address, transaction.chain_id)
-            .is_some()
-        {
+        if safe_proxy_address.is_some() {
             let original_estimate = estimated_gas_limit;
 
             // Safe proxy gas overhead calculation:
@@ -1256,7 +1294,7 @@ impl TransactionsQueue {
         working_transaction.gas_limit = Some(estimated_gas_limit);
         transaction.gas_limit = Some(estimated_gas_limit);
 
-        let (transaction_request, sent_with_blob_gas): (
+        let (mut transaction_request, mut sent_with_blob_gas): (
             TypedTransaction,
             Option<BlobGasPriceResult>,
         ) = if working_transaction.is_blob_transaction() {
@@ -1307,14 +1345,108 @@ impl TransactionsQueue {
             self.relayer.name
         );
 
+        // A broadcast blob transaction can only be replaced by another blob transaction
+        // (geth/reth reject cross-type replacements at the same nonce), so an expired one
+        // must keep being bumped as-is instead of being converted to a no-op
+        let can_replace_with_noop = !was_previously_sent || !transaction.is_blob_transaction();
+
+        if !transaction.is_noop && can_replace_with_noop && Self::has_expired(transaction) {
+            info!(
+                "Transaction {} expired before broadcast for relayer: {}, sending no-op replacement",
+                transaction.id, self.relayer.name
+            );
+
+            self.transaction_to_noop(transaction);
+            working_transaction = transaction.clone();
+            sent_with_blob_gas = None;
+
+            transaction_request = if self.is_legacy_transactions() {
+                working_transaction
+                    .to_legacy_typed_transaction_with_gas_limit(
+                        Some(&gas_price),
+                        Some(GasLimit::new(21_000)),
+                    )
+                    .map_err(|e| {
+                        TransactionQueueSendTransactionError::TransactionConversionError(
+                            e.to_string(),
+                        )
+                    })?
+            } else {
+                working_transaction
+                    .to_eip1559_typed_transaction_with_gas_limit(
+                        Some(&gas_price),
+                        Some(GasLimit::new(21_000)),
+                    )
+                    .map_err(|e| {
+                        TransactionQueueSendTransactionError::TransactionConversionError(
+                            e.to_string(),
+                        )
+                    })?
+            };
+        }
+
         info!(
             "Sending transaction {:?} to network for relayer: {}",
             transaction_request, self.relayer.name
         );
 
+        let mut signature =
+            self.evm_provider.sign_transaction(&self.relayer, &transaction_request).await.map_err(
+                |e| {
+                    TransactionQueueSendTransactionError::TransactionSendError(
+                        SendTransactionError::InternalError(e.to_string()),
+                    )
+                },
+            )?;
+
+        if !transaction.is_noop && can_replace_with_noop && Self::has_expired(transaction) {
+            info!(
+                "Transaction {} expired after signing for relayer: {}, signing no-op replacement",
+                transaction.id, self.relayer.name
+            );
+
+            self.transaction_to_noop(transaction);
+            working_transaction = transaction.clone();
+            sent_with_blob_gas = None;
+
+            transaction_request = if self.is_legacy_transactions() {
+                working_transaction
+                    .to_legacy_typed_transaction_with_gas_limit(
+                        Some(&gas_price),
+                        Some(GasLimit::new(21_000)),
+                    )
+                    .map_err(|e| {
+                        TransactionQueueSendTransactionError::TransactionConversionError(
+                            e.to_string(),
+                        )
+                    })?
+            } else {
+                working_transaction
+                    .to_eip1559_typed_transaction_with_gas_limit(
+                        Some(&gas_price),
+                        Some(GasLimit::new(21_000)),
+                    )
+                    .map_err(|e| {
+                        TransactionQueueSendTransactionError::TransactionConversionError(
+                            e.to_string(),
+                        )
+                    })?
+            };
+
+            signature = self
+                .evm_provider
+                .sign_transaction(&self.relayer, &transaction_request)
+                .await
+                .map_err(|e| {
+                    TransactionQueueSendTransactionError::TransactionSendError(
+                        SendTransactionError::InternalError(e.to_string()),
+                    )
+                })?;
+        }
+
         let transaction_hash = self
             .evm_provider
-            .send_transaction(&self.relayer, transaction_request)
+            .send_signed_transaction(transaction_request, signature)
             .await
             .map_err(TransactionQueueSendTransactionError::TransactionSendError)?;
 
@@ -1325,17 +1457,39 @@ impl TransactionsQueue {
             sent_with_blob_gas,
         };
 
+        transaction.known_transaction_hash = Some(transaction_sent.hash);
+        transaction.sent_with_max_fee_per_gas = Some(transaction_sent.sent_with_gas.max_fee);
+        transaction.sent_with_max_priority_fee_per_gas =
+            Some(transaction_sent.sent_with_gas.max_priority_fee);
+        transaction.sent_with_gas = Some(transaction_sent.sent_with_gas.clone());
+        transaction.sent_with_blob_gas = transaction_sent.sent_with_blob_gas.clone();
+        transaction.sent_at = Some(Utc::now());
+        transaction.status = TransactionStatus::INMEMPOOL;
+
         info!(
             "Transaction {} sent successfully with hash {} for relayer: {}",
             transaction_sent.id, transaction_sent.hash, self.relayer.name
         );
 
-        if transaction.sent_with_gas.is_none() || transaction.is_noop {
+        if !was_previously_sent || transaction.is_noop {
             info!(
                 "Updating database for sent transaction {} on relayer: {}",
                 transaction.id, self.relayer.name
             );
-            if transaction.sent_with_gas.is_none() {
+            // Persist the no-op fields before marking the transaction as sent so a crash
+            // between the two commits leaves a pending no-op row (safe to resend) rather
+            // than an inmempool row that still carries the original payload
+            if transaction.is_noop {
+                db.update_transaction_noop(
+                    &transaction.id,
+                    &transaction.to,
+                    &transaction.speed,
+                    &transaction.gas_limit.unwrap_or(GasLimit::new(21_000)),
+                )
+                .await?;
+            }
+
+            if !was_previously_sent {
                 db.transaction_sent(
                     &transaction_sent.id,
                     &transaction_sent.hash,
@@ -1344,8 +1498,6 @@ impl TransactionsQueue {
                     self.is_legacy_transactions(),
                 )
                 .await?;
-            } else if transaction.is_noop {
-                db.update_transaction_noop(&transaction.id, &transaction.to).await?;
             }
         } else {
             info!(

--- a/crates/core/src/transaction/queue_system/transactions_queues.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queues.rs
@@ -204,26 +204,15 @@ impl TransactionsQueues {
     }
 
     fn expires_at(&self) -> DateTime<Utc> {
-        Utc::now() + chrono::Duration::hours(12)
-    }
+        let expiration = std::env::var("RRELAYER_TRANSACTION_EXPIRATION_SECONDS")
+            .ok()
+            .and_then(|value| value.parse::<i64>().ok())
+            .filter(|seconds| *seconds > 0)
+            // try_seconds guards against values chrono::Duration::seconds would panic on
+            .and_then(chrono::Duration::try_seconds)
+            .unwrap_or_else(|| chrono::Duration::hours(12));
 
-    /// Checks if a transaction has expired.
-    fn has_expired(&self, transaction: &Transaction) -> bool {
-        transaction.expires_at < Utc::now()
-    }
-
-    /// Converts a transaction to a no-op transaction.
-    fn transaction_to_noop(
-        &self,
-        transactions_queue: &mut TransactionsQueue,
-        transaction: &mut Transaction,
-    ) {
-        transaction.to = transactions_queue.relay_address();
-        transaction.value = TransactionValue::zero();
-        transaction.data = TransactionData::empty();
-        transaction.gas_limit = Some(GasLimit::new(21000_u128));
-        transaction.is_noop = true;
-        transaction.speed = TransactionSpeed::FAST;
+        Utc::now() + expiration
     }
 
     /// Replaces the content of an existing transaction with new parameters.
@@ -1038,13 +1027,13 @@ impl TransactionsQueues {
                     );
                     ProcessPendingTransactionError::RelayerTransactionsQueueNotFound(*relayer_id)
                 })?;
-                if self.has_expired(&transaction) {
-                    self.transaction_to_noop(&mut transactions_queue, &mut transaction);
+                if TransactionsQueue::has_expired(&transaction) {
+                    transactions_queue.transaction_to_noop(&mut transaction);
                 }
 
                 match transactions_queue.send_transaction(&mut self.db, &mut transaction).await {
                     Ok(transaction_sent) => {
-                        transactions_queue.move_pending_to_inmempool(&transaction_sent).await
+                        transactions_queue.move_pending_to_inmempool(&transaction, &transaction_sent).await
                             .map_err(|e| ProcessPendingTransactionError::MovePendingTransactionToInmempoolError(*relayer_id, relayer_address, e))?;
 
                         self.invalidate_transaction_cache(&transaction.id).await;
@@ -1445,6 +1434,7 @@ impl TransactionsQueues {
                                     elapsed.num_milliseconds() as u64,
                                     &transaction.speed,
                                 ) {
+                                    let was_noop = transaction.is_noop;
                                     let transaction_sent = match transactions_queue
                                         .send_transaction(&mut self.db, &mut transaction)
                                         .await
@@ -1498,6 +1488,18 @@ impl TransactionsQueues {
                                     transactions_queue
                                         .update_inmempool_transaction_gas(&transaction_sent)
                                         .await;
+
+                                    // If the transaction expired mid-send and was replaced with a
+                                    // no-op, the inmempool entry must reflect that so it resolves
+                                    // to EXPIRED (not MINED) once the no-op lands
+                                    if !was_noop && transaction.is_noop {
+                                        transactions_queue
+                                            .update_inmempool_transaction_noop(
+                                                &transaction.id,
+                                                &transaction_sent,
+                                            )
+                                            .await;
+                                    }
 
                                     // Update the local transaction with the new gas values so subsequent bumps work correctly
                                     transaction.known_transaction_hash =

--- a/crates/e2e-tests/src/tests/transactions/status/expired.rs
+++ b/crates/e2e-tests/src/tests/transactions/status/expired.rs
@@ -1,11 +1,39 @@
 use crate::tests::test_runner::TestRunner;
+use anyhow::Context;
+use rrelayer_core::transaction::api::{RelayTransactionRequest, TransactionSpeed};
+use rrelayer_core::transaction::types::{TransactionData, TransactionStatus};
+use std::time::Duration;
 use tracing::info;
 
+/// Restores an environment variable to its previous value on drop, so the
+/// override cannot leak into other tests if this one panics or is cancelled
+/// by the harness timeout.
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
 impl TestRunner {
-    //TODO! NEED TO THINK ABOUT HOW TO TEST EXPIRED
     /// run single with:
     /// RRELAYER_PROVIDERS="raw" make run-test-debug TEST=transaction_status_expired
-    /// RRELAYER_PROVIDERS="privy" make run-test-debug TEST=transaction_status_expired  
+    /// RRELAYER_PROVIDERS="privy" make run-test-debug TEST=transaction_status_expired
     /// RRELAYER_PROVIDERS="aws_secret_manager" make run-test-debug TEST=transaction_status_expired
     /// RRELAYER_PROVIDERS="aws_kms" make run-test-debug TEST=transaction_status_expired
     /// RRELAYER_PROVIDERS="gcp_secret_manager" make run-test-debug TEST=transaction_status_expired
@@ -13,6 +41,74 @@ impl TestRunner {
     pub async fn transaction_status_expired(&self) -> anyhow::Result<()> {
         info!("Testing transaction expired state...");
 
-        Ok(())
+        let _expiration_guard = EnvVarGuard::set("RRELAYER_TRANSACTION_EXPIRATION_SECONDS", "1");
+
+        let relayer = self.create_and_fund_relayer("expired-status-relayer").await?;
+
+        relayer.update_max_gas_price(1).await?;
+
+        let tx_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.1")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-expired".to_string()),
+            blobs: None,
+        };
+
+        let send_result = relayer
+            .transaction()
+            .send(&tx_request, None)
+            .await
+            .context("Failed to queue transaction")?;
+
+        tokio::time::sleep(Duration::from_millis(1_200)).await;
+        relayer.remove_max_gas_price().await?;
+
+        for _ in 0..20 {
+            self.mine_and_wait().await?;
+
+            let status = relayer
+                .transaction()
+                .get_status(&send_result.id)
+                .await?
+                .context("Transaction status not found")?;
+
+            if status.status == TransactionStatus::EXPIRED {
+                let transaction = relayer
+                    .transaction()
+                    .get(&send_result.id)
+                    .await?
+                    .context("Transaction not found")?;
+
+                if !transaction.is_noop {
+                    anyhow::bail!("Expired transaction should be persisted as a no-op");
+                }
+                if transaction.to != transaction.from {
+                    anyhow::bail!("Expired no-op should be sent to the relayer address");
+                }
+                if !transaction.value.is_zero() {
+                    anyhow::bail!("Expired no-op should have zero value");
+                }
+                if !transaction.data.into_inner().is_empty() {
+                    anyhow::bail!("Expired no-op should have empty data");
+                }
+
+                info!("[SUCCESS] Transaction reached Expired state");
+                return Ok(());
+            }
+
+            if matches!(
+                status.status,
+                TransactionStatus::MINED | TransactionStatus::CONFIRMED | TransactionStatus::FAILED
+            ) {
+                anyhow::bail!(
+                    "Expected transaction to expire, but got terminal status: {:?}",
+                    status.status
+                );
+            }
+        }
+
+        anyhow::bail!("Transaction did not reach Expired state in time");
     }
 }

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -13,6 +13,7 @@
 ### Bug fixes
 
 - fix: make same-nonce replace and cancel transactions use deterministic gas bumps for raw provider e2e tests
+- fix: expire queued transactions before broadcast without blocking later nonces
 
 ---
 


### PR DESCRIPTION
## Summary
- convert queued transactions that expire before broadcast into nonce-preserving no-op transactions
- persist no-op transaction fields before moving them into mempool processing
- add an e2e regression for the queued expiry path and changelog entry

## Testing
- cargo fmt --all
- cargo fmt --all -- --check
- cargo clippy -- -D warnings -A clippy::uninlined_format_args
- cargo test --exclude rust-sdk-playground --workspace
- RRELAYER_MULTI_PROVIDER=1 RRELAYER_PROVIDERS="raw" RRELAYER_TEST_FILTER="transaction_status_expired" RUST_BACKTRACE=1 RUST_LOG=error cargo run --bin e2e-runner