### PR TITLE
fix: never strand a reserved nonce on send failures

### DIFF
--- a/crates/core/src/provider/evm_provider.rs
+++ b/crates/core/src/provider/evm_provider.rs
@@ -52,7 +52,7 @@ use tracing::info;
 
 pub type RelayerProvider = Box<dyn Provider<AnyNetwork> + Send + Sync>;
 
-const BLOCK_GAS_LIMIT_CACHE_TTL: Duration = Duration::from_secs(30);
+const BLOCK_GAS_LIMIT_CACHE_TTL: Duration = Duration::from_secs(600);
 
 #[derive(Clone)]
 struct BlockGasLimitCache {
@@ -479,11 +479,25 @@ impl EvmProvider {
             }
         }
 
-        let block = self.rpc_client().get_block_by_number(BlockNumberOrTag::Latest).await?.ok_or(
-            RpcError::Transport(TransportErrorKind::Custom(
-                "Latest block not found".to_string().into(),
-            )),
-        )?;
+        let block_result = self.rpc_client().get_block_by_number(BlockNumberOrTag::Latest).await;
+        let block = match block_result {
+            Ok(Some(block)) => block,
+            Ok(None) | Err(_) => {
+                // Serve the expired cached value on a transient RPC failure - the block
+                // gas limit moves slowly, and failing here would bubble up into the send
+                // path for a transaction that already holds a reserved nonce.
+                let cache = self.block_gas_limit_cache.lock().await;
+                if let Some(cached) = cache.as_ref() {
+                    return Ok(cached.gas_limit);
+                }
+                return match block_result {
+                    Err(e) => Err(e),
+                    _ => Err(RpcError::Transport(TransportErrorKind::Custom(
+                        "Latest block not found".to_string().into(),
+                    ))),
+                };
+            }
+        };
 
         let gas_limit = GasLimit::new(block.header.gas_limit as u128);
         let mut cache = self.block_gas_limit_cache.lock().await;
@@ -659,6 +673,7 @@ mod tests {
             rpc_clients: Vec::new(),
             wallet_manager,
             gas_estimator: Arc::new(UnusedGasEstimator),
+            block_gas_limit_cache: Arc::new(Mutex::new(None)),
             chain_id: ChainId::new(31337),
             name: "destination".to_string(),
             provider_urls: Vec::new(),

--- a/crates/core/src/transaction/db/builders.rs
+++ b/crates/core/src/transaction/db/builders.rs
@@ -38,5 +38,6 @@ pub fn build_transaction_from_transaction_view(row: &Row) -> Transaction {
         is_noop: to == from,
         external_id: row.get("external_id"),
         cancelled_by_transaction_id: row.get("cancelled_by_transaction_id"),
+        failed_reason: row.get("failed_reason"),
     }
 }

--- a/crates/core/src/transaction/db/write.rs
+++ b/crates/core/src/transaction/db/write.rs
@@ -488,6 +488,50 @@ impl PostgresClient {
         Ok(())
     }
 
+    /// Records the hash of a signed payload whose broadcast outcome is unknown (the
+    /// transaction row stays PENDING). Restores the ability to recognise the broadcast
+    /// as our own if it mines, even across a restart.
+    pub async fn transaction_update_known_hash(
+        &mut self,
+        transaction_id: &TransactionId,
+        transaction_hash: &TransactionHash,
+    ) -> Result<(), PostgresError> {
+        let mut conn = self.pool.get().await?;
+        let trans = conn.transaction().await.map_err(PostgresError::PgError)?;
+
+        trans
+            .execute(
+                "UPDATE relayer.transaction SET hash = $2 WHERE id = $1",
+                &[&transaction_id, &transaction_hash],
+            )
+            .await?;
+
+        trans
+            .execute(
+                "
+                    INSERT INTO relayer.transaction_audit_log (
+                        id, relayer_id, \"to\", \"from\", nonce, chain_id, data, value, blobs, gas_limit,
+                        speed, status, expires_at, queued_at, sent_at, mined_at, confirmed_at,
+                        failed_at, failed_reason, hash, sent_max_priority_fee_per_gas,
+                        sent_max_fee_per_gas, gas_price, block_hash, block_number, external_id
+                    )
+                    SELECT
+                        id, relayer_id, \"to\", \"from\", nonce, chain_id, data, value, blobs, gas_limit,
+                        speed, status, expires_at, queued_at, sent_at, mined_at, confirmed_at,
+                        failed_at, failed_reason, $2, sent_max_priority_fee_per_gas,
+                        sent_max_fee_per_gas, gas_price, block_hash, block_number, external_id
+                    FROM relayer.transaction
+                    WHERE id = $1;
+                ",
+                &[&transaction_id, &transaction_hash],
+            )
+            .await?;
+
+        trans.commit().await?;
+
+        Ok(())
+    }
+
     pub async fn transaction_expired(
         &mut self,
         transaction_id: &TransactionId,
@@ -547,6 +591,11 @@ impl PostgresClient {
             .as_ref()
             .map(|blob_gas| serde_json::to_value(blob_gas).unwrap_or(serde_json::Value::Null));
 
+        let truncated_failed_reason = transaction
+            .failed_reason
+            .as_ref()
+            .map(|reason| reason.chars().take(2000).collect::<String>());
+
         trans
             .execute(
                 "
@@ -572,7 +621,10 @@ impl PostgresClient {
                         sent_with_gas = $20,
                         sent_with_blob_gas = $21,
                         external_id = $22,
-                        cancelled_by_transaction_id = $23
+                        cancelled_by_transaction_id = $23,
+                        blobs = $24,
+                        failed_reason = $25,
+                        failed_at = CASE WHEN $25::TEXT IS NULL THEN failed_at ELSE NOW() END
                     WHERE id = $1
                 ",
                 &[
@@ -599,6 +651,8 @@ impl PostgresClient {
                     &sent_with_blob_gas_json,
                     &transaction.external_id,
                     &transaction.cancelled_by_transaction_id,
+                    &transaction.blobs,
+                    &truncated_failed_reason,
                 ],
             )
             .await

--- a/crates/core/src/transaction/queue_system/start.rs
+++ b/crates/core/src/transaction/queue_system/start.rs
@@ -100,6 +100,9 @@ async fn continuously_process_pending_transactions(
                             }
                             _ => {
                                 error!("Relayer id {} - PENDING QUEUE ERROR: {}", relayer_id, e);
+                                // Back off instead of hot-looping against a failing
+                                // node/signer - errors leave the transaction queued
+                                processes_next_break(&1000).await;
                             }
                         }
                     }
@@ -145,6 +148,9 @@ async fn continuously_process_inmempool_transactions(
                             }
                             _ => {
                                 error!("Relayer id {} - INMEMPOOL QUEUE ERROR: {}", relayer_id, e);
+                                // Back off instead of hot-looping against a failing
+                                // node/signer - errors leave the transaction queued
+                                processes_next_break(&1000).await;
                             }
                         }
                     }
@@ -190,6 +196,9 @@ async fn continuously_process_mined_transactions(
                             }
                             _ => {
                                 error!("Relayer id {} - MINED QUEUE ERROR: {}", relayer_id, e);
+                                // Back off instead of hot-looping against a failing
+                                // node/signer - errors leave the transaction queued
+                                processes_next_break(&1000).await;
                             }
                         }
                     }

--- a/crates/core/src/transaction/queue_system/transactions_queue.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queue.rs
@@ -1857,10 +1857,7 @@ mod tests {
             ("already known", SendErrorClass::AlreadyKnown),
             ("alreadyknown", SendErrorClass::AlreadyKnown),
             ("known transaction: 0xabc", SendErrorClass::AlreadyKnown),
-            (
-                "transaction with the same hash was already imported",
-                SendErrorClass::AlreadyKnown,
-            ),
+            ("transaction with the same hash was already imported", SendErrorClass::AlreadyKnown),
             // Nonce conflicts across client wordings
             ("nonce too low", SendErrorClass::NonceConflict),
             ("nonce is too low", SendErrorClass::NonceConflict),

--- a/crates/core/src/transaction/queue_system/transactions_queue.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queue.rs
@@ -33,12 +33,85 @@ use alloy::network::{AnyTransactionReceipt, ReceiptResponse};
 use alloy::{
     consensus::{SignableTransaction, TypedTransaction},
     hex,
+    primitives::Signature,
     transports::{RpcError, TransportErrorKind},
 };
 use chrono::Utc;
 use tokio::sync::Mutex;
 use tracing::error;
 use tracing::info;
+
+/// How the queue must react to a node's send/estimate error. Classification is
+/// centralised here so the pending loop, the gas-bump loop, and broadcast-hash
+/// recording can never drift apart on the same error string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendErrorClass {
+    /// Operator-fixable: the relayer cannot pay for the transaction right now.
+    /// Retry in place until it is topped up - the reserved nonce must not be dropped.
+    InsufficientFunds,
+    /// The node says this payload can never execute (would revert, intrinsic gas too
+    /// low, over the block gas cap). Close out: mark FAILED and consume the reserved
+    /// nonce with a same-nonce no-op.
+    PermanentRejection,
+    /// The identical signed payload is already live in the node's mempool - an earlier
+    /// broadcast succeeded. Never reassign this nonce; keep polling until it resolves.
+    AlreadyKnown,
+    /// The nonce was consumed by some broadcast. Check our own receipts before
+    /// concluding it was external and reassigning.
+    NonceConflict,
+    /// A same-nonce replacement was rejected for insufficient fee bump. The existing
+    /// broadcast is still live; retry with backoff.
+    Underpriced,
+    /// Transport failures and unrecognised wording - the outcome is unknown, retry.
+    Transient,
+}
+
+/// Classifies a lowercased node error message. Match order matters: permanent
+/// rejections are checked first because a revert reason can quote any wording -
+/// 'execution reverted: ERC20: transfer amount exceeds balance' must not be read
+/// as relayer-insufficient-funds, and 'execution reverted: invalid nonce' (common
+/// in forwarder/meta-tx contracts) must not trigger nonce resynchronisation -
+/// while genuine node-level nonce/mempool/funds errors never contain 'execution
+/// reverted'. geth's 'gas required exceeds allowance' is a balance-capped
+/// estimation (operator-fixable), not a payload defect.
+pub fn classify_send_error(error_msg: &str) -> SendErrorClass {
+    if error_msg.contains("execution reverted")
+        || error_msg.contains("invalid opcode")
+        || error_msg.contains("intrinsic gas too low")
+        || error_msg.contains("exceeds block gas limit")
+        || error_msg.contains("oversized data")
+        || error_msg.contains("max initcode size exceeded")
+        || error_msg.contains("maxtxsizeexceeded")
+    {
+        return SendErrorClass::PermanentRejection;
+    }
+    if error_msg.contains("already known")
+        || error_msg.contains("alreadyknown")
+        || error_msg.contains("known transaction")
+        || error_msg.contains("already imported")
+    {
+        return SendErrorClass::AlreadyKnown;
+    }
+    if error_msg.contains("nonce too low")
+        || error_msg.contains("nonce is too low")
+        || error_msg.contains("invalid nonce")
+        || error_msg.contains("nonce has already been used")
+        || error_msg.contains("oldnonce")
+    {
+        return SendErrorClass::NonceConflict;
+    }
+    if error_msg.contains("insufficient funds")
+        || error_msg.contains("insufficientfunds")
+        || error_msg.contains("gas required exceeds allowance")
+        || error_msg.contains("overshot")
+    {
+        return SendErrorClass::InsufficientFunds;
+    }
+    if error_msg.contains("underpriced") || error_msg.contains("feetoolow") {
+        return SendErrorClass::Underpriced;
+    }
+    SendErrorClass::Transient
+}
 
 fn bump_u128_by_at_least_one(value: u128) -> u128 {
     value + std::cmp::max(value / 20, 1)
@@ -306,22 +379,6 @@ impl TransactionsQueue {
         }
     }
 
-    pub async fn move_next_pending_to_failed(&mut self) {
-        let mut transactions = self.pending_transactions.lock().await;
-        if let Some(tx) = transactions.front() {
-            info!(
-                "Moving pending transaction {} to failed for relayer: {}",
-                tx.id, self.relayer.name
-            );
-        }
-        transactions.pop_front();
-        info!(
-            "Remaining pending transactions for relayer {}: {}",
-            self.relayer.name,
-            transactions.len()
-        );
-    }
-
     pub async fn remove_pending_transaction_by_id(
         &mut self,
         transaction_id: &TransactionId,
@@ -543,11 +600,21 @@ impl TransactionsQueue {
                     // is_noop is derived as to == from when rehydrating from the database,
                     // so also require the noop shape (zero value, empty data) to avoid
                     // misclassifying a genuine user self-send as expired after a restart
-                    let winner_status = if receipt.status()
-                        && comp_tx.competitive.is_none()
-                        && comp_tx.original.is_noop
+                    let noop_payload_shape = comp_tx.original.is_noop
                         && comp_tx.original.value.is_zero()
-                        && comp_tx.original.data == TransactionData::empty()
+                        && comp_tx.original.data == TransactionData::empty();
+                    let winner_status = if receipt.status()
+                        && noop_payload_shape
+                        && comp_tx.original.failed_reason.is_some()
+                    {
+                        // The payload was permanently rejected at send time and replaced
+                        // with this no-op purely to consume the reserved nonce - surface
+                        // the transaction to the caller as FAILED, not MINED. This holds
+                        // even when a cancel/replace competitor lost the race to it.
+                        TransactionStatus::FAILED
+                    } else if receipt.status()
+                        && noop_payload_shape
+                        && comp_tx.competitive.is_none()
                         && Self::has_expired(&comp_tx.original)
                     {
                         TransactionStatus::EXPIRED
@@ -1083,6 +1150,16 @@ impl TransactionsQueue {
 
         let signature = self.evm_provider.sign_transaction(&self.relayer, transaction).await?;
 
+        let tx_hash = Self::signed_transaction_hash(transaction, signature);
+        info!("Computed transaction hash {} for relayer: {}", tx_hash, self.relayer.name);
+        Ok(tx_hash)
+    }
+
+    /// Computes the on-chain hash of an already-signed payload without re-signing.
+    fn signed_transaction_hash(
+        transaction: &TypedTransaction,
+        signature: Signature,
+    ) -> TransactionHash {
         let hash = match transaction {
             TypedTransaction::Legacy(tx) => {
                 let signed = tx.clone().into_signed(signature);
@@ -1106,9 +1183,7 @@ impl TransactionsQueue {
             }
         };
 
-        let tx_hash = TransactionHash::from_alloy_hash(&hash);
-        info!("Computed transaction hash {} for relayer: {}", tx_hash, self.relayer.name);
-        Ok(tx_hash)
+        TransactionHash::from_alloy_hash(&hash)
     }
 
     pub async fn estimate_gas(
@@ -1173,23 +1248,81 @@ impl TransactionsQueue {
         Ok(estimated_gas_result)
     }
 
-    async fn validate_gas_limit_within_block_cap(
+    /// Advisory only: the cached block gas limit can be stale (or the RPC briefly
+    /// down), and a false positive here would burn a reserved nonce on a transaction
+    /// the chain would accept. The node's own send rejection ('exceeds block gas
+    /// limit') is the authoritative permanent signal.
+    async fn warn_if_gas_limit_over_block_cap(&self, gas_limit: GasLimit) {
+        match self.evm_provider.get_block_gas_limit().await {
+            Ok(block_gas_limit) => {
+                if gas_limit > block_gas_limit {
+                    error!(
+                        "Transaction gas limit {} exceeds latest block gas limit {} for relayer: {} - the node is expected to reject this send",
+                        gas_limit.into_inner(),
+                        block_gas_limit.into_inner(),
+                        self.relayer.name
+                    );
+                }
+            }
+            Err(e) => {
+                info!(
+                    "Could not fetch block gas limit for advisory check on relayer {}: {}",
+                    self.relayer.name, e
+                );
+            }
+        }
+    }
+
+    /// True when the node's send error proves the submitted payload was rejected and is
+    /// definitively not in the mempool - as opposed to transport failures, where the
+    /// broadcast may have been accepted with the response lost.
+    fn send_error_rules_out_broadcast(error_msg: &str) -> bool {
+        matches!(
+            classify_send_error(error_msg),
+            SendErrorClass::InsufficientFunds
+                | SendErrorClass::PermanentRejection
+                | SendErrorClass::NonceConflict
+                | SendErrorClass::Underpriced
+        ) || error_msg.contains("invalid signature")
+    }
+
+    /// Records the hash of a signed payload whose broadcast outcome is unknown, in both
+    /// the in-memory pending entry and the database, so a later 'nonce too low' receipt
+    /// check can recognise the broadcast as our own instead of reassigning its nonce.
+    async fn record_broadcast_attempt_hash(
         &self,
-        gas_limit: GasLimit,
-    ) -> Result<(), RpcError<TransportErrorKind>> {
-        let block_gas_limit = self.evm_provider.get_block_gas_limit().await?;
-        if gas_limit > block_gas_limit {
-            return Err(RpcError::Transport(TransportErrorKind::Custom(
-                format!(
-                    "Transaction gas limit {} exceeds latest block gas limit {}",
-                    gas_limit.into_inner(),
-                    block_gas_limit.into_inner()
-                )
-                .into(),
-            )));
+        db: &mut PostgresClient,
+        transaction: &mut Transaction,
+        attempt_hash: TransactionHash,
+    ) {
+        if transaction.known_transaction_hash == Some(attempt_hash) {
+            return;
         }
 
-        Ok(())
+        info!(
+            "Recording broadcast attempt hash {} for transaction {} on relayer: {} (send outcome unknown)",
+            attempt_hash, transaction.id, self.relayer.name
+        );
+
+        transaction.known_transaction_hash = Some(attempt_hash);
+
+        {
+            let mut transactions = self.pending_transactions.lock().await;
+            if let Some(stored) = transactions.iter_mut().find(|tx| tx.id == transaction.id) {
+                stored.known_transaction_hash = Some(attempt_hash);
+            }
+        }
+
+        if let Err(db_error) =
+            db.transaction_update_known_hash(&transaction.id, &attempt_hash).await
+        {
+            // In-memory state is already updated; worst case a crash falls back to the
+            // previously recorded candidate hash
+            error!(
+                "Failed to persist broadcast attempt hash for transaction {}: {}",
+                transaction.id, db_error
+            );
+        }
     }
 
     pub async fn send_transaction(
@@ -1378,9 +1511,7 @@ impl TransactionsQueue {
             );
         }
 
-        self.validate_gas_limit_within_block_cap(estimated_gas_limit)
-            .await
-            .map_err(TransactionQueueSendTransactionError::TransactionEstimateGasError)?;
+        self.warn_if_gas_limit_over_block_cap(estimated_gas_limit).await;
 
         working_transaction.gas_limit = Some(estimated_gas_limit);
         transaction.gas_limit = Some(estimated_gas_limit);
@@ -1535,11 +1666,26 @@ impl TransactionsQueue {
                 })?;
         }
 
-        let transaction_hash = self
-            .evm_provider
-            .send_signed_transaction(transaction_request, signature)
-            .await
-            .map_err(TransactionQueueSendTransactionError::TransactionSendError)?;
+        let attempt_hash = Self::signed_transaction_hash(&transaction_request, signature);
+
+        let transaction_hash =
+            match self.evm_provider.send_signed_transaction(transaction_request, signature).await {
+                Ok(hash) => hash,
+                Err(error) => {
+                    // A transport-level failure is ambiguous: the node may have accepted the
+                    // broadcast even though the response was lost ('already known' proves it
+                    // did). Record the hash of the exact signed payload we attempted so the
+                    // 'nonce too low' receipt check can recognise the broadcast as our own if
+                    // it mines. A definitive node rejection means this payload is NOT in the
+                    // mempool, so the previously recorded candidate must be kept.
+                    if !was_previously_sent
+                        && !Self::send_error_rules_out_broadcast(&error.to_string().to_lowercase())
+                    {
+                        self.record_broadcast_attempt_hash(db, transaction, attempt_hash).await;
+                    }
+                    return Err(TransactionQueueSendTransactionError::TransactionSendError(error));
+                }
+            };
 
         let transaction_sent = TransactionSentWithRelayer {
             id: transaction.id,
@@ -1665,6 +1811,81 @@ impl TransactionsQueue {
             if let Some(transaction) = competitive_tx.get_transaction_by_id_mut(transaction_id) {
                 transaction.nonce = new_nonce;
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_send_error, SendErrorClass};
+
+    #[test]
+    fn classify_send_error_covers_node_wordings() {
+        let cases: Vec<(&str, SendErrorClass)> = vec![
+            // Permanent rejections - checked before funds because revert reasons
+            // routinely contain the word 'balance'
+            (
+                "execution reverted: erc20: transfer amount exceeds balance",
+                SendErrorClass::PermanentRejection,
+            ),
+            (
+                "execution reverted: ownable: caller is not the owner",
+                SendErrorClass::PermanentRejection,
+            ),
+            ("execution reverted", SendErrorClass::PermanentRejection),
+            // Revert reasons quoting nonce/mempool wording must NOT be mistaken
+            // for node-level nonce conflicts - resynchronising would re-broadcast
+            // a permanently reverting payload forever
+            ("execution reverted: invalid nonce", SendErrorClass::PermanentRejection),
+            ("execution reverted: fwd: nonce too low", SendErrorClass::PermanentRejection),
+            ("invalid opcode: opcode 0xfe not defined", SendErrorClass::PermanentRejection),
+            ("intrinsic gas too low", SendErrorClass::PermanentRejection),
+            ("exceeds block gas limit", SendErrorClass::PermanentRejection),
+            // Size-cap rejections (geth's oversized data / EIP-3860 initcode cap,
+            // nethermind's MaxTxSizeExceeded) can never succeed on resend
+            ("oversized data", SendErrorClass::PermanentRejection),
+            ("max initcode size exceeded", SendErrorClass::PermanentRejection),
+            ("maxtxsizeexceeded", SendErrorClass::PermanentRejection),
+            // Operator-fixable funding conditions - including geth's balance-capped
+            // estimation wording, which must NOT be treated as a payload defect
+            ("insufficient funds for gas * price + value", SendErrorClass::InsufficientFunds),
+            ("gas required exceeds allowance (21000)", SendErrorClass::InsufficientFunds),
+            ("insufficient funds for transfer", SendErrorClass::InsufficientFunds),
+            ("insufficientfunds, balance is too low", SendErrorClass::InsufficientFunds),
+            ("overshot 5000", SendErrorClass::InsufficientFunds),
+            // Mempool-presence signals across client wordings
+            ("already known", SendErrorClass::AlreadyKnown),
+            ("alreadyknown", SendErrorClass::AlreadyKnown),
+            ("known transaction: 0xabc", SendErrorClass::AlreadyKnown),
+            (
+                "transaction with the same hash was already imported",
+                SendErrorClass::AlreadyKnown,
+            ),
+            // Nonce conflicts across client wordings
+            ("nonce too low", SendErrorClass::NonceConflict),
+            ("nonce is too low", SendErrorClass::NonceConflict),
+            ("invalid nonce", SendErrorClass::NonceConflict),
+            ("nonce has already been used", SendErrorClass::NonceConflict),
+            ("oldnonce", SendErrorClass::NonceConflict),
+            // Fee-bump rejections keep the existing broadcast alive
+            ("replacement transaction underpriced", SendErrorClass::Underpriced),
+            ("transaction underpriced", SendErrorClass::Underpriced),
+            ("feetoolow", SendErrorClass::Underpriced),
+            ("feetoolowtocompete", SendErrorClass::Underpriced),
+            // Unknown wording / transport failures must stay retryable - never
+            // close out (which burns the nonce) on an unrecognised string
+            ("connection refused", SendErrorClass::Transient),
+            ("request timed out", SendErrorClass::Transient),
+            ("load balancer error 502", SendErrorClass::Transient),
+            ("txpool is full", SendErrorClass::Transient),
+        ];
+
+        for (message, expected) in cases {
+            assert_eq!(
+                classify_send_error(message),
+                expected,
+                "misclassified node error: {message}"
+            );
         }
     }
 }

--- a/crates/core/src/transaction/queue_system/transactions_queues.rs
+++ b/crates/core/src/transaction/queue_system/transactions_queues.rs
@@ -5,6 +5,7 @@ use std::{
 
 use alloy::{
     consensus::TypedTransaction,
+    network::AnyTransactionReceipt,
     transports::{RpcError, TransportErrorKind},
 };
 use chrono::{DateTime, Utc};
@@ -23,14 +24,14 @@ pub enum TransactionsQueuesError {
 
 use super::{
     start::spawn_processing_tasks_for_relayer,
-    transactions_queue::TransactionsQueue,
+    transactions_queue::{classify_send_error, SendErrorClass, TransactionsQueue},
     types::{
         AddTransactionError, CancelTransactionError, CancelTransactionResult, CompetitionType,
         EditableTransactionType, ProcessInmempoolStatus, ProcessInmempoolTransactionError,
         ProcessMinedStatus, ProcessMinedTransactionError, ProcessPendingStatus,
         ProcessPendingTransactionError, ProcessResult, ReplaceTransactionError,
-        ReplaceTransactionResult, TransactionRelayerSetup, TransactionToSend,
-        TransactionsQueueSetup,
+        ReplaceTransactionResult, TransactionRelayerSetup, TransactionSentWithRelayer,
+        TransactionToSend, TransactionsQueueSetup,
     },
 };
 use crate::transaction::api::RelayTransactionRequest;
@@ -44,13 +45,19 @@ use crate::{
     postgres::{PostgresClient, PostgresConnectionError},
     relayer::RelayerId,
     safe_proxy::SafeProxyManager,
-    shared::{cache::Cache, common_types::WalletOrProviderError},
+    shared::{
+        cache::Cache,
+        common_types::{EvmAddress, WalletOrProviderError},
+    },
     shutdown::enter_critical_operation,
     transaction::{
         cache::invalidate_transaction_no_state_cache,
         nonce_manager::NonceManager,
         queue_system::types::TransactionQueueSendTransactionError,
-        types::{Transaction, TransactionData, TransactionId, TransactionStatus, TransactionValue},
+        types::{
+            Transaction, TransactionData, TransactionHash, TransactionId, TransactionStatus,
+            TransactionValue,
+        },
     },
     webhooks::WebhookManager,
 };
@@ -420,6 +427,7 @@ impl TransactionsQueues {
             sent_with_blob_gas: None,
             external_id: transaction_to_send.external_id.clone(),
             cancelled_by_transaction_id: None,
+            failed_reason: None,
         };
 
         let (gas_price, blob_gas_price) = Self::compute_transaction_gas_prices(
@@ -585,6 +593,7 @@ impl TransactionsQueues {
                             sent_with_blob_gas: None,
                             external_id: Some(format!("cancel_{}", transaction.id)),
                             cancelled_by_transaction_id: None,
+                            failed_reason: None,
                         };
 
                         info!("cancel_transaction: creating higher gas cancel transaction for inmempool tx with same nonce {:?}", cancel_transaction.nonce);
@@ -837,6 +846,7 @@ impl TransactionsQueues {
                                 .clone()
                                 .or_else(|| Some(format!("replace_{}", transaction.id))),
                             cancelled_by_transaction_id: None,
+                            failed_reason: None,
                         };
 
                         info!("replace_transaction: creating competitive replace transaction for inmempool tx with same nonce {:?}", replace_transaction.nonce);
@@ -1034,6 +1044,153 @@ impl TransactionsQueues {
         Ok(())
     }
 
+    /// Closes out a pending transaction whose payload the node has permanently rejected
+    /// (it would revert on-chain, its intrinsic gas is too low, or its gas limit cannot
+    /// fit in a block). The caller-visible outcome is FAILED, but the reserved nonce
+    /// still has to be consumed on-chain, so the queue entry is converted in place to a
+    /// same-nonce no-op self-send (exactly like cancel does) instead of being dropped -
+    /// dropping it would strand the nonce and wedge every transaction queued behind it.
+    /// The DB row stays PENDING (with failed_reason set) so a crash before the no-op
+    /// mines still rehydrates it; the no-op's receipt then resolves the status to FAILED.
+    async fn close_out_pending_transaction_as_noop(
+        &mut self,
+        transactions_queue: &mut TransactionsQueue,
+        transaction: &mut Transaction,
+        reason: &str,
+    ) -> Result<ProcessResult<ProcessPendingStatus>, ProcessPendingTransactionError> {
+        error!(
+            "process_single_pending: transaction {} permanently rejected ({}); replacing payload with a same-nonce no-op so nonce {} is still consumed",
+            transaction.id,
+            reason,
+            transaction.nonce.into_inner()
+        );
+
+        // Snapshot BEFORE the no-op conversion so the failure webhook carries the
+        // user's original payload, not the internal self-send that replaces it
+        let original_payload = transaction.clone();
+
+        transactions_queue.transaction_to_noop(transaction);
+        transaction.known_transaction_hash = None;
+        transaction.sent_with_gas = None;
+        transaction.sent_with_max_fee_per_gas = None;
+        transaction.sent_with_max_priority_fee_per_gas = None;
+        transaction.sent_at = None;
+        transaction.status = TransactionStatus::PENDING;
+        transaction.failed_reason = Some(reason.to_string());
+        transactions_queue.update_pending_transaction(transaction.clone()).await;
+
+        // Single atomic write: transaction_update persists the no-op payload together
+        // with failed_reason (and the audit row), so a crash can never separate them
+        if let Err(db_error) = self.db.transaction_update(transaction).await {
+            // In-memory queue is consistent; a restart re-runs this close-out.
+            error!(
+                "close_out_pending_transaction_as_noop: failed to persist no-op payload for transaction {}: {}",
+                transaction.id, db_error
+            );
+        }
+
+        self.invalidate_transaction_cache(&transaction.id).await;
+
+        if let Some(webhook_manager) = &self.webhook_manager {
+            let webhook_manager = webhook_manager.clone();
+            let failed_transaction = Transaction {
+                status: TransactionStatus::FAILED,
+                failed_reason: Some(reason.to_string()),
+                ..original_payload
+            };
+            tokio::spawn(async move {
+                let webhook_manager = webhook_manager.lock().await;
+                webhook_manager.on_transaction_failed(&failed_transaction).await;
+            });
+        }
+
+        // The no-op broadcasts on the next tick at the same nonce
+        Ok(ProcessResult::<ProcessPendingStatus>::other(
+            ProcessPendingStatus::ClosedOutWithNoop,
+            Some(&100),
+        ))
+    }
+
+    /// Resolves a pending transaction whose earlier broadcast turned out to have mined
+    /// (detected via a receipt for its known hash after a 'nonce too low' send error).
+    /// Moves it into the inmempool queue under the mined hash so normal receipt
+    /// resolution completes it - reassigning a fresh nonce here would broadcast the
+    /// payload a second time.
+    async fn resolve_pending_transaction_mined(
+        &mut self,
+        relayer_id: &RelayerId,
+        relayer_address: EvmAddress,
+        transactions_queue: &mut TransactionsQueue,
+        transaction: &Transaction,
+        mined_hash: TransactionHash,
+        receipt: &AnyTransactionReceipt,
+    ) -> Result<ProcessResult<ProcessPendingStatus>, ProcessPendingTransactionError> {
+        // Gas fields here are bookkeeping for an already-mined broadcast - take what
+        // the chain actually charged from the receipt instead of quoting the oracle
+        let effective_gas_price = receipt.effective_gas_price;
+        let transaction_sent = TransactionSentWithRelayer {
+            id: transaction.id,
+            hash: mined_hash,
+            sent_with_gas: GasPriceResult {
+                max_fee: MaxFee::new(effective_gas_price),
+                max_priority_fee: MaxPriorityFee::new(effective_gas_price),
+                min_wait_time_estimate: None,
+                max_wait_time_estimate: None,
+            },
+            sent_with_blob_gas: None,
+        };
+
+        transactions_queue
+            .move_pending_to_inmempool(transaction, &transaction_sent)
+            .await
+            .map_err(|e| {
+                ProcessPendingTransactionError::MovePendingTransactionToInmempoolError(
+                    *relayer_id,
+                    relayer_address,
+                    e,
+                )
+            })?;
+
+        if let Err(db_error) = self
+            .db
+            .transaction_sent(
+                &transaction_sent.id,
+                &transaction_sent.hash,
+                &transaction_sent.sent_with_gas,
+                transaction_sent.sent_with_blob_gas.as_ref(),
+                transactions_queue.is_legacy_transactions(),
+            )
+            .await
+        {
+            // The in-memory queue is consistent; a restart replays this resolution.
+            error!(
+                "resolve_pending_transaction_mined: failed to persist mined hash for transaction {}: {}",
+                transaction.id, db_error
+            );
+        }
+
+        self.invalidate_transaction_cache(&transaction.id).await;
+
+        if let Some(webhook_manager) = &self.webhook_manager {
+            let webhook_manager = webhook_manager.clone();
+            let sent_transaction = Transaction {
+                status: TransactionStatus::INMEMPOOL,
+                known_transaction_hash: Some(transaction_sent.hash),
+                sent_at: Some(Utc::now()),
+                ..transaction.clone()
+            };
+            tokio::spawn(async move {
+                let webhook_manager = webhook_manager.lock().await;
+                webhook_manager.on_transaction_sent(&sent_transaction).await;
+            });
+        }
+
+        Ok(ProcessResult::<ProcessPendingStatus>::other(
+            ProcessPendingStatus::NonceSynchronized,
+            Some(&100),
+        ))
+    }
+
     pub async fn process_single_pending(
         &mut self,
         relayer_id: &RelayerId,
@@ -1104,78 +1261,128 @@ impl TransactionsQueues {
                             TransactionQueueSendTransactionError::TransactionEstimateGasError(
                                 error,
                             ) => {
-                                self.db
-                                    .update_transaction_failed(&transaction.id, &error.to_string())
-                                    .await
-                                    .map_err(|e| {
-                                        ProcessPendingTransactionError::DbError(
-                                            *relayer_id,
-                                            relayer_address,
-                                            e,
-                                        )
-                                    })?;
-
-                                transactions_queue.move_next_pending_to_failed().await;
-
-                                self.invalidate_transaction_cache(&transaction.id).await;
-
-                                Err(ProcessPendingTransactionError::TransactionEstimateGasError(
-                                    *relayer_id,
-                                    relayer_address,
-                                    error,
-                                ))
-                            }
-                            TransactionQueueSendTransactionError::TransactionSendError(error) => {
                                 let error_msg = error.to_string().to_lowercase();
-                                // Check if this is an insufficient funds error - auto-fail these
-                                let insufficient_funds = error_msg.contains("insufficient funds")
-                                    || error_msg.contains("balance")
-                                    || error_msg.contains("overshot");
-                                let will_revert = error_msg.contains("execution reverted");
-                                let intrinsic_gas_too_low =
-                                    error_msg.contains("intrinsic gas too low");
-                                if insufficient_funds || will_revert || intrinsic_gas_too_low {
-                                    if insufficient_funds {
-                                        error!("process_single_pending: transaction {} failed due to insufficient funds moved to failed - error {}", transaction.id, error_msg);
+                                match classify_send_error(&error_msg) {
+                                    SendErrorClass::InsufficientFunds => {
+                                        // Operator-fixable (includes geth's balance-capped
+                                        // 'gas required exceeds allowance'): retry until the
+                                        // relayer is topped up
+                                        error!(
+                                            "process_single_pending: transaction {} gas estimation hit insufficient relayer funds - retrying until topped up - {}",
+                                            transaction.id, error
+                                        );
+                                        Ok(ProcessResult::<ProcessPendingStatus>::other(
+                                            ProcessPendingStatus::SendRetrying,
+                                            self.relayer_block_times_ms.get(relayer_id),
+                                        ))
                                     }
-                                    if will_revert {
-                                        error!("process_single_pending: transaction {} failed as would always revert - error {}", transaction.id, error_msg);
-                                    }
-                                    if intrinsic_gas_too_low {
-                                        error!("process_single_pending: transaction {} failed due to intrinsic gas too low - error {}", transaction.id, error_msg);
-                                    }
-                                    self.db
-                                        .update_transaction_failed(
-                                            &transaction.id,
+                                    SendErrorClass::PermanentRejection => {
+                                        // The node says this payload can never execute -
+                                        // close it out as FAILED while a same-nonce no-op
+                                        // consumes the reserved nonce
+                                        self.close_out_pending_transaction_as_noop(
+                                            &mut transactions_queue,
+                                            &mut transaction,
                                             &error.to_string(),
                                         )
                                         .await
-                                        .map_err(|e| {
-                                            ProcessPendingTransactionError::DbError(
-                                                *relayer_id,
-                                                relayer_address,
-                                                e,
-                                            )
-                                        })?;
-
-                                    transactions_queue.move_next_pending_to_failed().await;
-
-                                    self.invalidate_transaction_cache(&transaction.id).await;
-
-                                    Err(ProcessPendingTransactionError::SendTransactionError(
-                                        *relayer_id,
-                                        relayer_address,
-                                        TransactionQueueSendTransactionError::TransactionSendError(
-                                            error,
-                                        ),
+                                    }
+                                    _ => {
+                                        // Transient RPC issue - the nonce is already
+                                        // reserved, so stay queued and retry
+                                        error!(
+                                            "process_single_pending: transaction {} gas estimation issue at send time - {}; leaving pending for retry",
+                                            transaction.id, error
+                                        );
+                                        Ok(ProcessResult::<ProcessPendingStatus>::other(
+                                            ProcessPendingStatus::SendRetrying,
+                                            self.relayer_block_times_ms.get(relayer_id),
+                                        ))
+                                    }
+                                }
+                            }
+                            TransactionQueueSendTransactionError::TransactionSendError(error) => {
+                                let error_msg = error.to_string().to_lowercase();
+                                let error_class = classify_send_error(&error_msg);
+                                if error_class == SendErrorClass::InsufficientFunds {
+                                    // Operator-fixable: the nonce was reserved at admission,
+                                    // so terminally failing here would strand the nonce and
+                                    // wedge every transaction queued behind it. Retry - once
+                                    // the relayer is topped up the queue drains on its own.
+                                    error!("process_single_pending: transaction {} cannot broadcast (insufficient relayer funds) - retrying until the relayer is topped up - error {}", transaction.id, error_msg);
+                                    Ok(ProcessResult::<ProcessPendingStatus>::other(
+                                        ProcessPendingStatus::SendRetrying,
+                                        self.relayer_block_times_ms.get(relayer_id),
                                     ))
-                                } else if error_msg.contains("nonce too low")
-                                    || error_msg.contains("nonce is too low")
-                                    || error_msg.contains("invalid nonce")
-                                    || error_msg.contains("nonce has already been used")
-                                    || error_msg.contains("already known")
-                                {
+                                } else if error_class == SendErrorClass::PermanentRejection {
+                                    // Permanently rejected payload - close it out as FAILED
+                                    // while a same-nonce no-op consumes the reserved nonce
+                                    self.close_out_pending_transaction_as_noop(
+                                        &mut transactions_queue,
+                                        &mut transaction,
+                                        &error.to_string(),
+                                    )
+                                    .await
+                                } else if error_class == SendErrorClass::AlreadyKnown {
+                                    // The identical signed transaction is already live in the
+                                    // node's mempool - an earlier broadcast succeeded but its
+                                    // response was lost. This is success, not a nonce desync:
+                                    // reassigning a fresh nonce here would execute the payload
+                                    // twice. Wait a block rather than re-signing every tick -
+                                    // once the live copy mines, the next attempt returns
+                                    // 'nonce too low' and the receipt check below resolves it.
+                                    info!(
+                                        "process_single_pending: transaction {} already in mempool from a previous broadcast; waiting for it to resolve",
+                                        transaction.id
+                                    );
+                                    Ok(ProcessResult::<ProcessPendingStatus>::other(
+                                        ProcessPendingStatus::SendRetrying,
+                                        self.relayer_block_times_ms.get(relayer_id),
+                                    ))
+                                } else if error_class == SendErrorClass::NonceConflict {
                                     warn!("process_single_pending: nonce synchronization issue detected for relayer {}: {}", relayer_id, error);
+
+                                    // Before reassigning a fresh nonce, check whether OUR OWN
+                                    // broadcast of this transaction is what consumed the nonce
+                                    // (a prior lost-response send that mined). Reassigning in
+                                    // that case would execute the payload a second time.
+                                    if let Some(known_hash) = transaction.known_transaction_hash {
+                                        match transactions_queue.get_receipt(&known_hash).await {
+                                            Ok(Some(receipt)) => {
+                                                info!(
+                                                    "process_single_pending: transaction {} already mined as {} - handing over to receipt resolution instead of reassigning its nonce",
+                                                    transaction.id, known_hash
+                                                );
+                                                return self
+                                                    .resolve_pending_transaction_mined(
+                                                        relayer_id,
+                                                        relayer_address,
+                                                        &mut transactions_queue,
+                                                        &transaction,
+                                                        known_hash,
+                                                        &receipt,
+                                                    )
+                                                    .await;
+                                            }
+                                            Ok(None) => {}
+                                            Err(receipt_error) => {
+                                                // Fail closed: without the receipt we cannot rule
+                                                // out that our own broadcast consumed the nonce,
+                                                // and reassigning would risk executing the payload
+                                                // twice. Retry the whole check next tick.
+                                                warn!(
+                                                    "process_single_pending: could not check receipt for transaction {} ({}) - retrying before touching its nonce",
+                                                    transaction.id, receipt_error
+                                                );
+                                                return Ok(
+                                                    ProcessResult::<ProcessPendingStatus>::other(
+                                                        ProcessPendingStatus::SendRetrying,
+                                                        Some(&100),
+                                                    ),
+                                                );
+                                            }
+                                        }
+                                    }
 
                                     if let Err(sync_error) = self
                                         .recover_nonce_synchronization(
@@ -1255,47 +1462,32 @@ impl TransactionsQueues {
                             TransactionQueueSendTransactionError::TransactionConversionError(
                                 error,
                             ) => {
-                                self.db
-                                    .update_transaction_failed(&transaction.id, &error)
-                                    .await
-                                    .map_err(|e| {
-                                        ProcessPendingTransactionError::DbError(
-                                            *relayer_id,
-                                            relayer_address,
-                                            e,
-                                        )
-                                    })?;
-
-                                transactions_queue.move_next_pending_to_failed().await;
-
-                                self.invalidate_transaction_cache(&transaction.id).await;
-
-                                Err(ProcessPendingTransactionError::TransactionEstimateGasError(
-                                    *relayer_id,
-                                    relayer_address,
-                                    RpcError::Transport(TransportErrorKind::Custom(error.into())),
+                                // Dominated by transient causes: remote signer outages are
+                                // wrapped into conversion errors, and for Safe relayers the
+                                // Safe wrapping/signing only happens at send time. Keep the
+                                // nonce-holding transaction queued and retry; a genuinely
+                                // unconvertible payload is closed out via cancel (same-nonce
+                                // no-op).
+                                error!(
+                                    "process_single_pending: transaction {} conversion issue at send time - {}; leaving pending for retry",
+                                    transaction.id, error
+                                );
+                                Ok(ProcessResult::<ProcessPendingStatus>::other(
+                                    ProcessPendingStatus::SendRetrying,
+                                    self.relayer_block_times_ms.get(relayer_id),
                                 ))
                             }
                             TransactionQueueSendTransactionError::SafeProxyError(error) => {
-                                self.db
-                                    .update_transaction_failed(&transaction.id, &error.to_string())
-                                    .await
-                                    .map_err(|e| {
-                                        ProcessPendingTransactionError::DbError(
-                                            *relayer_id,
-                                            relayer_address,
-                                            e,
-                                        )
-                                    })?;
-
-                                transactions_queue.move_next_pending_to_failed().await;
-
-                                self.invalidate_transaction_cache(&transaction.id).await;
-
-                                Err(ProcessPendingTransactionError::TransactionEstimateGasError(
-                                    *relayer_id,
-                                    relayer_address,
-                                    RpcError::Transport(TransportErrorKind::Custom(error.into())),
+                                // Reading the Safe contract nonce is a live eth_call on every
+                                // send - a transient RPC failure here must not drop the
+                                // nonce-holding transaction.
+                                error!(
+                                    "process_single_pending: transaction {} safe proxy issue at send time - {}; leaving pending for retry",
+                                    transaction.id, error
+                                );
+                                Ok(ProcessResult::<ProcessPendingStatus>::other(
+                                    ProcessPendingStatus::SendRetrying,
+                                    self.relayer_block_times_ms.get(relayer_id),
                                 ))
                             }
                             TransactionQueueSendTransactionError::NoTransactionInQueue => {
@@ -1403,23 +1595,38 @@ impl TransactionsQueues {
                                     }
                                 }
                                 TransactionStatus::FAILED => {
+                                    // A close-out no-op carries the node's original
+                                    // rejection reason - preserve it instead of the
+                                    // generic on-chain-failure message
+                                    let was_closed_out =
+                                        competition_result.winner.failed_reason.is_some();
+                                    let failed_reason = competition_result
+                                        .winner
+                                        .failed_reason
+                                        .clone()
+                                        .unwrap_or_else(|| "Failed onchain".to_string());
                                     self.db
-                                        .update_transaction_failed(&competition_result.winner.id, "Failed onchain")
+                                        .update_transaction_failed(&competition_result.winner.id, &failed_reason)
                                         .await.map_err(|e| ProcessInmempoolTransactionError::CouldNotUpdateTransactionStatusInTheDatabase(*relayer_id, relayer_address, competition_result.winner.clone(), TransactionStatus::FAILED, e))?;
                                     self.invalidate_transaction_cache(
                                         &competition_result.winner.id,
                                     )
                                     .await;
 
-                                    if let Some(webhook_manager) = &self.webhook_manager {
-                                        let webhook_manager = webhook_manager.clone();
-                                        let failed_transaction = competition_result.winner.clone();
-                                        tokio::spawn(async move {
-                                            let webhook_manager = webhook_manager.lock().await;
-                                            webhook_manager
-                                                .on_transaction_failed(&failed_transaction)
-                                                .await;
-                                        });
+                                    // Close-outs already fired their failure webhook with
+                                    // the original payload when the rejection happened
+                                    if !was_closed_out {
+                                        if let Some(webhook_manager) = &self.webhook_manager {
+                                            let webhook_manager = webhook_manager.clone();
+                                            let failed_transaction =
+                                                competition_result.winner.clone();
+                                            tokio::spawn(async move {
+                                                let webhook_manager = webhook_manager.lock().await;
+                                                webhook_manager
+                                                    .on_transaction_failed(&failed_transaction)
+                                                    .await;
+                                            });
+                                        }
                                     }
                                 }
                                 _ => {}
@@ -1474,13 +1681,51 @@ impl TransactionsQueues {
                                         Ok(tx_sent) => tx_sent,
                                         Err(TransactionQueueSendTransactionError::TransactionSendError(error)) => {
                                             let error_msg = error.to_string().to_lowercase();
-                                            if error_msg.contains("nonce too low")
-                                                || error_msg.contains("nonce is too low")
-                                                || error_msg.contains("invalid nonce")
-                                                || error_msg.contains("nonce has already been used")
-                                                || error_msg.contains("already known")
-                                            {
+                                            let error_class = classify_send_error(&error_msg);
+                                            if error_class == SendErrorClass::AlreadyKnown {
+                                                // The bumped payload is already in the node's
+                                                // pool (a previous broadcast succeeded but the
+                                                // response was lost). Keep polling the receipt -
+                                                // never reassign the nonce of a live transaction,
+                                                // and wait a block rather than re-signing per tick.
+                                                info!("process_single_inmempool: gas bump for transaction {} already in mempool; continuing receipt polling", transaction.id);
+                                                return Ok(ProcessResult::<ProcessInmempoolStatus>::other(
+                                                    ProcessInmempoolStatus::StillInmempool,
+                                                    self.relayer_block_times_ms.get(relayer_id),
+                                                ));
+                                            }
+                                            if error_class == SendErrorClass::NonceConflict {
                                                 warn!("process_single_inmempool: nonce synchronization issue detected for relayer {} during gas bump: {}", relayer_id, error);
+
+                                                // 'nonce too low' during a bump most commonly
+                                                // means this very transaction mined between the
+                                                // receipt poll and the bump send. Check the
+                                                // receipt before assuming the nonce was consumed
+                                                // externally - reassigning a mined transaction a
+                                                // fresh nonce would re-execute its payload and
+                                                // strand the newly reserved nonce forever.
+                                                if let Some(known_hash) = transaction.known_transaction_hash {
+                                                    match transactions_queue.get_receipt(&known_hash).await {
+                                                        Ok(Some(_receipt)) => {
+                                                            info!("process_single_inmempool: transaction {} mined as {} during bump race; letting receipt resolution complete it", transaction.id, known_hash);
+                                                            return Ok(ProcessResult::<ProcessInmempoolStatus>::other(
+                                                                ProcessInmempoolStatus::StillInmempool,
+                                                                Some(&100),
+                                                            ));
+                                                        }
+                                                        Ok(None) => {}
+                                                        Err(receipt_error) => {
+                                                            // Fail closed: without the receipt we cannot rule out that
+                                                            // this transaction mined, and reassigning its nonce would
+                                                            // risk executing the payload twice. Retry next tick.
+                                                            warn!("process_single_inmempool: could not check receipt for transaction {} ({}) - retrying before touching its nonce", transaction.id, receipt_error);
+                                                            return Ok(ProcessResult::<ProcessInmempoolStatus>::other(
+                                                                ProcessInmempoolStatus::StillInmempool,
+                                                                Some(&100),
+                                                            ));
+                                                        }
+                                                    }
+                                                }
 
                                                 if let Err(sync_error) = self.recover_nonce_synchronization(relayer_id, &mut transactions_queue).await {
                                                     error!("Failed to recover nonce synchronization for relayer {}: {}", relayer_id, sync_error);

--- a/crates/core/src/transaction/queue_system/types/process_queue_result.rs
+++ b/crates/core/src/transaction/queue_system/types/process_queue_result.rs
@@ -32,6 +32,15 @@ pub enum ProcessPendingStatus {
     GasPriceTooHigh,
     GasCalculationUnavailable,
     NonceSynchronized,
+    /// The send attempt failed with a condition that is transient or operator-fixable
+    /// (insufficient funds, RPC outage, signer outage). The transaction keeps its
+    /// reserved nonce and stays at the head of the pending queue: dropping it would
+    /// permanently strand the nonce and wedge every transaction queued behind it.
+    SendRetrying,
+    /// The node permanently rejected the payload (would revert, intrinsic gas too low,
+    /// over the block gas cap). The transaction was marked failed and converted in
+    /// place to a same-nonce no-op so its reserved nonce is still consumed on-chain.
+    ClosedOutWithNoop,
 }
 
 impl ProcessResultSuccess for ProcessPendingStatus {

--- a/crates/core/src/transaction/queue_system/types/transactions_queues_custom_errors.rs
+++ b/crates/core/src/transaction/queue_system/types/transactions_queues_custom_errors.rs
@@ -149,12 +149,6 @@ pub enum ProcessPendingTransactionError {
         EvmAddress,
         MovePendingTransactionToInmempoolError,
     ),
-
-    #[error("Relayer id {0} / address {1} - Transaction estimate gas error: {2}")]
-    TransactionEstimateGasError(RelayerId, EvmAddress, RpcError<TransportErrorKind>),
-
-    #[error("Relayer id {0} / address {1} - Transaction could not be updated in DB: {2}")]
-    DbError(RelayerId, EvmAddress, PostgresError),
 }
 
 #[derive(Error, Debug)]

--- a/crates/core/src/transaction/types/transaction.rs
+++ b/crates/core/src/transaction/types/transaction.rs
@@ -113,6 +113,12 @@ pub struct Transaction {
 
     #[serde(rename = "cancelledByTransactionId", skip_serializing_if = "Option::is_none", default)]
     pub cancelled_by_transaction_id: Option<TransactionId>,
+
+    /// Set when the node permanently rejected this transaction's payload and the queue
+    /// replaced it with a same-nonce no-op; once that no-op mines the transaction
+    /// resolves to FAILED (instead of MINED/EXPIRED) carrying this reason.
+    #[serde(rename = "failedReason", skip_serializing_if = "Option::is_none", default)]
+    pub failed_reason: Option<String>,
 }
 
 impl Display for Transaction {

--- a/crates/e2e-tests/src/infrastructure/contract_interactions.rs
+++ b/crates/e2e-tests/src/infrastructure/contract_interactions.rs
@@ -417,6 +417,43 @@ impl ContractInteractor {
         Err(anyhow::anyhow!("Could not find deployed contract address in forge output"))
     }
 
+    pub async fn approve_tokens(
+        &self,
+        spender: &Address,
+        amount: U256,
+        from_private_key: &str,
+    ) -> Result<()> {
+        let token_address = self.token_address.context("Token not deployed yet")?;
+
+        let signer: PrivateKeySigner = from_private_key.parse().context("Invalid private key")?;
+        let wallet = EthereumWallet::from(signer);
+
+        let provider_url_str = "http://localhost:8545"; // Use default URL
+        let approve_provider = ProviderBuilder::new()
+            .wallet(wallet)
+            .connect(provider_url_str)
+            .await
+            .context("Failed to connect to provider")?;
+
+        let token_contract = TestToken::new(token_address.into(), &approve_provider);
+        let approve_call = token_contract.approve(*spender, amount);
+        let pending_tx = approve_call.send().await.context("Failed to approve tokens")?;
+
+        info!("Approved {} tokens for {:?}, tx: {:?}", amount, spender, pending_tx.tx_hash());
+
+        Ok(())
+    }
+
+    pub fn encode_token_transfer_from(
+        &self,
+        from: &Address,
+        to: &Address,
+        amount: U256,
+    ) -> Vec<u8> {
+        use alloy::sol_types::SolCall;
+        TestToken::transferFromCall { from: *from, to: *to, amount }.abi_encode()
+    }
+
     pub async fn transfer_tokens(
         &self,
         to_address: &Address,

--- a/crates/e2e-tests/src/tests/test_runner.rs
+++ b/crates/e2e-tests/src/tests/test_runner.rs
@@ -165,6 +165,80 @@ impl TestRunner {
         Ok(())
     }
 
+    /// Sends a transaction FROM an arbitrary address via anvil impersonation and mines
+    /// it - used to consume a relayer's nonce externally (simulating the relayer key
+    /// being used outside the relayer).
+    pub async fn send_impersonated_transaction(
+        &self,
+        from: &EvmAddress,
+        to: &EvmAddress,
+        value: U256,
+    ) -> anyhow::Result<()> {
+        let anvil_url = format!("http://127.0.0.1:{}", self.config.anvil_port);
+        let client = reqwest::Client::new();
+
+        let calls = [
+            serde_json::json!({"jsonrpc": "2.0", "method": "anvil_impersonateAccount", "params": [from.into_address()], "id": 9990}),
+            serde_json::json!({"jsonrpc": "2.0", "method": "eth_sendTransaction", "params": [{"from": from.into_address(), "to": to.into_address(), "value": format!("0x{:x}", value)}], "id": 9991}),
+            serde_json::json!({"jsonrpc": "2.0", "method": "anvil_mine", "params": [1], "id": 9992}),
+            serde_json::json!({"jsonrpc": "2.0", "method": "anvil_stopImpersonatingAccount", "params": [from.into_address()], "id": 9993}),
+        ];
+
+        for call in &calls {
+            let response = client
+                .post(&anvil_url)
+                .header("Content-Type", "application/json")
+                .json(call)
+                .send()
+                .await
+                .context("Failed impersonated anvil call")?;
+            let body: serde_json::Value = response.json().await?;
+            anyhow::ensure!(
+                body.get("error").is_none(),
+                "impersonated call failed: {:?} -> {:?}",
+                call["method"],
+                body["error"]
+            );
+        }
+
+        info!("Sent impersonated transaction from {} (nonce consumed externally)", from);
+        Ok(())
+    }
+
+    /// Overwrite an account's balance directly via anvil_setBalance (no mining needed),
+    /// used to simulate a relayer running out of funds between admission and send.
+    pub async fn set_relayer_balance(
+        &self,
+        relayer_address: &EvmAddress,
+        balance: U256,
+    ) -> anyhow::Result<()> {
+        let anvil_url = format!("http://127.0.0.1:{}", self.config.anvil_port);
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "anvil_setBalance",
+            "params": [relayer_address.into_address(), format!("0x{:x}", balance)],
+            "id": 9998
+        });
+
+        let response = reqwest::Client::new()
+            .post(&anvil_url)
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to call anvil_setBalance")?;
+
+        anyhow::ensure!(
+            response.status().is_success(),
+            "anvil_setBalance failed: {}",
+            response.status()
+        );
+
+        info!("Set relayer {} balance to {} wei", relayer_address, balance);
+        Ok(())
+    }
+
     pub async fn create_relayer(&self, name: &str) -> anyhow::Result<AdminRelayerClient> {
         let relayer = self
             .relayer_client

--- a/crates/e2e-tests/src/tests/transactions/mod.rs
+++ b/crates/e2e-tests/src/tests/transactions/mod.rs
@@ -7,6 +7,7 @@ mod gas_estimation;
 mod get;
 mod list;
 mod nonce_management;
+mod nonce_stuck;
 mod replace;
 mod send_blob;
 mod send_contract_interaction;
@@ -120,6 +121,26 @@ impl TestModule for TransactionTests {
                 "transaction_nonce_management",
                 "Transaction nonce management",
                 |runner| Box::pin(runner.transaction_nonce_management()),
+            ),
+            TestDefinition::new(
+                "transaction_insufficient_funds_at_send_retries",
+                "Send-time insufficient funds retries until topped up (no stranded nonce)",
+                |runner| Box::pin(runner.transaction_insufficient_funds_at_send_retries()),
+            ),
+            TestDefinition::new(
+                "transaction_cancel_noop_low_balance_retries",
+                "Cancel no-op retries on drained balance (no stranded nonce)",
+                |runner| Box::pin(runner.transaction_cancel_noop_low_balance_retries()),
+            ),
+            TestDefinition::new(
+                "transaction_external_nonce_displacement_recovers",
+                "External nonce displacement recovers with a fresh nonce (no stranded nonce)",
+                |runner| Box::pin(runner.transaction_external_nonce_displacement_recovers()),
+            ),
+            TestDefinition::new(
+                "transaction_onchain_revert_does_not_strand_nonce",
+                "On-chain revert resolves FAILED and consumes its nonce (no stranded nonce)",
+                |runner| Box::pin(runner.transaction_onchain_revert_does_not_strand_nonce()),
             ),
             TestDefinition::new(
                 "transaction_concurrent",

--- a/crates/e2e-tests/src/tests/transactions/nonce_stuck.rs
+++ b/crates/e2e-tests/src/tests/transactions/nonce_stuck.rs
@@ -1,0 +1,412 @@
+use crate::tests::test_runner::TestRunner;
+use anyhow::Context;
+use rrelayer_core::transaction::api::{RelayTransactionRequest, TransactionSpeed};
+use rrelayer_core::transaction::types::{TransactionData, TransactionStatus};
+use std::time::Duration;
+use tracing::info;
+
+impl TestRunner {
+    /// A transient insufficient-funds failure at send time must never terminally fail a
+    /// transaction: the nonce was reserved at admission, so dropping the transaction
+    /// permanently strands that nonce and wedges every transaction queued behind it.
+    /// Low balance is operator-fixable — once topped up, the queue must drain on its own.
+    ///
+    /// run single with:
+    /// RRELAYER_PROVIDERS="raw" make run-test-debug TEST=transaction_insufficient_funds_at_send_retries
+    pub async fn transaction_insufficient_funds_at_send_retries(&self) -> anyhow::Result<()> {
+        info!("Testing send-time insufficient funds retries until topped up...");
+
+        let relayer = self.create_and_fund_relayer("insufficient-funds-retry-relayer").await?;
+        let relayer_address = relayer.address().await?;
+
+        // Hold sends so both transactions are admitted (nonces reserved) while balance is healthy
+        relayer.update_max_gas_price(1).await?;
+
+        let tx_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.5")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-insufficient-funds-head".to_string()),
+            blobs: None,
+        };
+        let head_tx = relayer
+            .transaction()
+            .send(&tx_request, None)
+            .await
+            .context("Failed to queue head transaction")?;
+
+        let follow_up_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.3")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-insufficient-funds-followup".to_string()),
+            blobs: None,
+        };
+        let follow_up_tx = relayer
+            .transaction()
+            .send(&follow_up_request, None)
+            .await
+            .context("Failed to queue follow-up transaction")?;
+
+        // Drain the relayer below the head transaction's cost, then release the sends
+        self.set_relayer_balance(
+            &relayer_address,
+            alloy::primitives::utils::parse_ether("0.0001")?,
+        )
+        .await?;
+        relayer.remove_max_gas_price().await?;
+
+        // The send attempt now fails with insufficient funds. The transaction must stay
+        // PENDING (retrying) — terminally failing it strands the reserved nonce forever.
+        for _ in 0..12 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            let status = relayer
+                .transaction()
+                .get_status(&head_tx.id)
+                .await?
+                .context("Head transaction status not found")?;
+
+            anyhow::ensure!(
+                status.status != TransactionStatus::FAILED,
+                "BUG: transaction was terminally failed on a transient insufficient-funds send \
+                 error — its reserved nonce is stranded and the relayer queue is wedged"
+            );
+            anyhow::ensure!(
+                status.status == TransactionStatus::PENDING,
+                "Test setup broken: expected head transaction to sit PENDING on a drained \
+                 balance, got {:?}",
+                status.status
+            );
+        }
+
+        // Operator fixes the balance — everything must drain with no manual intervention
+        self.fund_relayer(&relayer_address, alloy::primitives::utils::parse_ether("10")?).await?;
+
+        self.wait_for_transaction_completion(&head_tx.id)
+            .await
+            .context("Head transaction did not recover after balance top-up")?;
+
+        self.wait_for_transaction_completion(&follow_up_tx.id)
+            .await
+            .context("Follow-up transaction stuck behind head nonce after top-up")?;
+
+        // Nonce continuity: a fresh transaction must also mine (no gap was created)
+        let continuity_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.1")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-insufficient-funds-continuity".to_string()),
+            blobs: None,
+        };
+        let continuity_tx = relayer
+            .transaction()
+            .send(&continuity_request, None)
+            .await
+            .context("Failed to queue continuity transaction")?;
+
+        self.wait_for_transaction_completion(&continuity_tx.id)
+            .await
+            .context("Continuity transaction did not mine — nonce sequence has a gap")?;
+
+        info!("[SUCCESS] Insufficient funds at send retried until topped up, no nonce stranded");
+        Ok(())
+    }
+
+    /// The cancel-of-pending no-op (which exists to consume the cancelled transaction's
+    /// reserved nonce) must itself survive a drained balance: if the no-op send fails with
+    /// insufficient funds it must retry, not be terminally failed — otherwise the safety
+    /// net defeats itself and the nonce is stranded anyway.
+    ///
+    /// run single with:
+    /// RRELAYER_PROVIDERS="raw" make run-test-debug TEST=transaction_cancel_noop_low_balance_retries
+    pub async fn transaction_cancel_noop_low_balance_retries(&self) -> anyhow::Result<()> {
+        info!("Testing cancel no-op retries on drained balance...");
+
+        let relayer = self.create_and_fund_relayer("cancel-noop-lowbalance-relayer").await?;
+        let relayer_address = relayer.address().await?;
+
+        relayer.update_max_gas_price(1).await?;
+
+        let tx_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.5")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-cancel-noop-head".to_string()),
+            blobs: None,
+        };
+        let head_tx = relayer
+            .transaction()
+            .send(&tx_request, None)
+            .await
+            .context("Failed to queue head transaction")?;
+
+        let follow_up_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.3")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-cancel-noop-followup".to_string()),
+            blobs: None,
+        };
+        let follow_up_tx = relayer
+            .transaction()
+            .send(&follow_up_request, None)
+            .await
+            .context("Failed to queue follow-up transaction")?;
+
+        // Cancel the still-pending head: it converts in place to a nonce-preserving no-op
+        let cancel_result = relayer
+            .transaction()
+            .cancel(&head_tx.id, None)
+            .await
+            .context("Failed to cancel head transaction")?;
+        anyhow::ensure!(cancel_result.success, "Cancel of pending transaction failed");
+
+        // Drain the balance below even the no-op's gas cost, then release the sends
+        self.set_relayer_balance(&relayer_address, alloy::primitives::U256::from(1u64)).await?;
+        relayer.remove_max_gas_price().await?;
+
+        // The no-op send fails with insufficient funds — it must keep retrying
+        for _ in 0..12 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            let status = relayer
+                .transaction()
+                .get_status(&head_tx.id)
+                .await?
+                .context("Cancelled transaction status not found")?;
+
+            anyhow::ensure!(
+                status.status != TransactionStatus::FAILED,
+                "BUG: the cancel no-op was terminally failed on a transient insufficient-funds \
+                 send error — the nonce it exists to consume is stranded"
+            );
+            anyhow::ensure!(
+                status.status == TransactionStatus::PENDING,
+                "Test setup broken: expected cancel no-op to sit PENDING on a drained balance, \
+                 got {:?}",
+                status.status
+            );
+        }
+
+        self.fund_relayer(&relayer_address, alloy::primitives::utils::parse_ether("10")?).await?;
+
+        let cancelled = self
+            .wait_for_transaction_terminal(&head_tx.id)
+            .await
+            .context("Cancel no-op did not reach a terminal state after top-up")?;
+        anyhow::ensure!(
+            cancelled.is_noop,
+            "Cancelled transaction should have completed as a no-op"
+        );
+
+        self.wait_for_transaction_completion(&follow_up_tx.id)
+            .await
+            .context("Follow-up transaction stuck behind cancelled nonce after top-up")?;
+
+        info!("[SUCCESS] Cancel no-op retried on drained balance and recovered after top-up");
+        Ok(())
+    }
+
+    /// If the relayer's key is used OUTSIDE the relayer (consuming its next nonce),
+    /// the queued transaction's send fails with 'nonce too low'. Recovery must
+    /// reassign it a fresh nonce and drain the whole queue - never wedge it.
+    ///
+    /// run single with:
+    /// RRELAYER_PROVIDERS="raw" make run-test-debug TEST=transaction_external_nonce_displacement_recovers
+    pub async fn transaction_external_nonce_displacement_recovers(&self) -> anyhow::Result<()> {
+        info!("Testing external nonce displacement recovery...");
+
+        let relayer = self.create_and_fund_relayer("nonce-displacement-relayer").await?;
+        let relayer_address = relayer.address().await?;
+
+        // Hold sends so both transactions are admitted with reserved nonces
+        relayer.update_max_gas_price(1).await?;
+
+        let head_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.2")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-displacement-head".to_string()),
+            blobs: None,
+        };
+        let head_tx = relayer
+            .transaction()
+            .send(&head_request, None)
+            .await
+            .context("Failed to queue head transaction")?;
+
+        let follow_up_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.1")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-displacement-followup".to_string()),
+            blobs: None,
+        };
+        let follow_up_tx = relayer
+            .transaction()
+            .send(&follow_up_request, None)
+            .await
+            .context("Failed to queue follow-up transaction")?;
+
+        // Consume the head transaction's reserved nonce from OUTSIDE the relayer
+        self.send_impersonated_transaction(
+            &relayer_address,
+            &self.config.anvil_accounts[1],
+            alloy::primitives::utils::parse_ether("0.01")?,
+        )
+        .await?;
+
+        relayer.remove_max_gas_price().await?;
+
+        // The head send hits 'nonce too low'; recovery must reassign a fresh nonce
+        // (after confirming via receipt that OUR broadcast did not consume it) and
+        // every queued transaction must still mine
+        self.wait_for_transaction_completion(&head_tx.id)
+            .await
+            .context("Displaced head transaction did not recover with a fresh nonce")?;
+
+        self.wait_for_transaction_completion(&follow_up_tx.id)
+            .await
+            .context("Follow-up transaction stuck after external nonce displacement")?;
+
+        let continuity_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.05")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-displacement-continuity".to_string()),
+            blobs: None,
+        };
+        let continuity_tx = relayer
+            .transaction()
+            .send(&continuity_request, None)
+            .await
+            .context("Failed to queue continuity transaction")?;
+        self.wait_for_transaction_completion(&continuity_tx.id)
+            .await
+            .context("Continuity transaction did not mine after displacement recovery")?;
+
+        info!("[SUCCESS] External nonce displacement recovered, no nonce stranded");
+        Ok(())
+    }
+
+    /// A transaction that reverts ON-CHAIN (state changed between admission and
+    /// execution) consumes its nonce via the mined revert and resolves FAILED. The
+    /// queue must move straight on to the next transaction.
+    ///
+    /// run single with:
+    /// RRELAYER_PROVIDERS="raw" make run-test-debug TEST=transaction_onchain_revert_does_not_strand_nonce
+    pub async fn transaction_onchain_revert_does_not_strand_nonce(&self) -> anyhow::Result<()> {
+        use alloy::signers::local::PrivateKeySigner;
+
+        info!("Testing on-chain revert nonce continuity...");
+
+        let relayer = self.create_and_fund_relayer("mined-revert-relayer").await?;
+        let relayer_address = relayer.address().await?;
+
+        let token = self.contract_interactor.token_address().context("Test token not deployed")?;
+        let deployer_key = self.config.anvil_private_keys[0].clone();
+        let deployer_signer: PrivateKeySigner = deployer_key.parse()?;
+        let deployer_address = deployer_signer.address();
+
+        // Deployer approves the relayer; the approval survives the balance drain below
+        let amount = alloy::primitives::U256::from(100u64);
+        self.contract_interactor
+            .approve_tokens(&relayer_address.into_address(), amount, &deployer_key)
+            .await?;
+        self.mine_and_wait().await?;
+
+        // Hold sends, then admit the transferFrom while the deployer still has tokens
+        // (gas estimation passes)
+        relayer.update_max_gas_price(1).await?;
+
+        let calldata = self.contract_interactor.encode_token_transfer_from(
+            &deployer_address,
+            &self.config.anvil_accounts[1].into_address(),
+            amount,
+        );
+        let revert_request = RelayTransactionRequest {
+            to: token,
+            value: alloy::primitives::U256::ZERO.into(),
+            data: TransactionData::new(calldata.into()),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-mined-revert".to_string()),
+            blobs: None,
+        };
+        let revert_tx = relayer
+            .transaction()
+            .send(&revert_request, None)
+            .await
+            .context("Failed to queue transferFrom transaction")?;
+
+        let follow_up_request = RelayTransactionRequest {
+            to: self.config.anvil_accounts[1],
+            value: alloy::primitives::utils::parse_ether("0.1")?.into(),
+            data: TransactionData::empty(),
+            speed: Some(TransactionSpeed::FAST),
+            external_id: Some("test-mined-revert-followup".to_string()),
+            blobs: None,
+        };
+        let follow_up_tx = relayer
+            .transaction()
+            .send(&follow_up_request, None)
+            .await
+            .context("Failed to queue follow-up transaction")?;
+
+        // Drain the deployer's token balance so the queued transferFrom reverts at
+        // execution time (nodes do not simulate on submission)
+        let deployer_balance =
+            self.contract_interactor.get_token_balance(&deployer_address).await?;
+        self.contract_interactor
+            .transfer_tokens(
+                &self.config.anvil_accounts[2].into_address(),
+                deployer_balance,
+                &deployer_key,
+            )
+            .await?;
+        self.mine_and_wait().await?;
+
+        relayer.remove_max_gas_price().await?;
+
+        // The transferFrom broadcasts, mines as reverted, and must resolve FAILED
+        let mut saw_failed = false;
+        for _ in 0..30 {
+            self.mine_and_wait().await?;
+            let status = relayer
+                .transaction()
+                .get_status(&revert_tx.id)
+                .await?
+                .context("Revert transaction status not found")?;
+            match status.status {
+                TransactionStatus::FAILED => {
+                    saw_failed = true;
+                    break;
+                }
+                TransactionStatus::MINED | TransactionStatus::CONFIRMED => {
+                    anyhow::bail!(
+                        "Expected the transferFrom to revert on-chain, but it {:?}",
+                        status.status
+                    );
+                }
+                _ => tokio::time::sleep(Duration::from_millis(300)).await,
+            }
+        }
+        anyhow::ensure!(saw_failed, "Reverting transaction never resolved FAILED");
+
+        // The mined revert consumed the nonce - the follow-up must mine
+        self.wait_for_transaction_completion(&follow_up_tx.id)
+            .await
+            .context("Follow-up transaction stuck behind mined revert")?;
+
+        info!("[SUCCESS] On-chain revert resolved FAILED with no stranded nonce");
+        Ok(())
+    }
+}

--- a/crates/e2e-tests/src/tests/transactions/status/expired.rs
+++ b/crates/e2e-tests/src/tests/transactions/status/expired.rs
@@ -94,6 +94,27 @@ impl TestRunner {
                     anyhow::bail!("Expired no-op should have empty data");
                 }
 
+                // The expiry no-op consumed the reserved nonce - a fresh transaction
+                // must mine straight away (no gap left behind)
+                let _expiration_reset =
+                    EnvVarGuard::set("RRELAYER_TRANSACTION_EXPIRATION_SECONDS", "3600");
+                let continuity_request = RelayTransactionRequest {
+                    to: self.config.anvil_accounts[1],
+                    value: alloy::primitives::utils::parse_ether("0.05")?.into(),
+                    data: TransactionData::empty(),
+                    speed: Some(TransactionSpeed::FAST),
+                    external_id: Some("test-expired-continuity".to_string()),
+                    blobs: None,
+                };
+                let continuity_tx = relayer
+                    .transaction()
+                    .send(&continuity_request, None)
+                    .await
+                    .context("Failed to queue continuity transaction")?;
+                self.wait_for_transaction_completion(&continuity_tx.id)
+                    .await
+                    .context("Continuity transaction stuck behind expired nonce")?;
+
                 info!("[SUCCESS] Transaction reached Expired state");
                 return Ok(());
             }

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -8,6 +8,7 @@
 
 - feat: add YAML-driven cron jobs for recurring relayer transactions and contract calls, with persisted last-run state across restarts
 - feat: run raw provider e2e tests in CI for pull requests and pushes
+- feat: expose failedReason on transactions so API and SDK consumers can read why a payload was permanently rejected
 
 ---
 
@@ -21,6 +22,10 @@
 - fix: preserve transaction nonce order when cancelling pending transactions
 - fix: make same-nonce replace and cancel transactions use deterministic gas bumps for raw provider e2e tests
 - fix: expire queued transactions before broadcast without blocking later nonces
+- fix: retry sends on insufficient relayer funds instead of failing the transaction so topping up drains the queue with no stranded nonce
+- fix: close out permanently rejected payloads as FAILED via a same-nonce no-op so the reserved nonce is always consumed
+- fix: check the transaction's own receipt before reassigning a nonce during desync recovery and treat already-known responses as a live broadcast, preventing duplicate execution
+- fix: classify node send errors centrally so revert reasons mentioning balance and geth's gas-allowance wording are routed correctly
 
 ---
 

--- a/documentation/rrelayer/docs/pages/integration/api/transactions.mdx
+++ b/documentation/rrelayer/docs/pages/integration/api/transactions.mdx
@@ -201,6 +201,23 @@ For transactions with status `CANCELLED`, additional fields are included:
 }
 ```
 
+#### Additional Fields for Failed Transactions
+
+When the node permanently rejects a transaction's payload (for example it would
+always revert), the relayer marks it `FAILED` and consumes its reserved nonce with
+a same-nonce no-op so the queue is never blocked. `failedReason` carries the node's
+rejection reason:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440003",
+  "status": "FAILED",
+  "isNoop": true,
+  "failedReason": "execution reverted: ERC20: transfer amount exceeds balance",
+  ...
+}
+```
+
 ### Example
 
 ```bash

--- a/documentation/rrelayer/docs/pages/integration/sdk/transactions/node.mdx
+++ b/documentation/rrelayer/docs/pages/integration/sdk/transactions/node.mdx
@@ -432,6 +432,7 @@ export interface Transaction {
   isNoop: boolean; // cancelled transaction
   externalId?: string | null;
   cancelledByTransactionId?: string | null;
+  failedReason?: string | null; // node's rejection reason when the payload was permanently rejected
 }
 ```
 

--- a/documentation/rrelayer/docs/pages/integration/sdk/transactions/rust.mdx
+++ b/documentation/rrelayer/docs/pages/integration/sdk/transactions/rust.mdx
@@ -702,6 +702,12 @@ pub struct Transaction {
 
     #[serde(rename = "cancelledByTransactionId", skip_serializing_if = "Option::is_none", default)]
     pub cancelled_by_transaction_id: Option<TransactionId>,
+
+    /// Set when the node permanently rejected this transaction's payload and the queue
+    /// replaced it with a same-nonce no-op; once that no-op mines the transaction
+    /// resolves to FAILED carrying this reason.
+    #[serde(rename = "failedReason", skip_serializing_if = "Option::is_none", default)]
+    pub failed_reason: Option<String>,
 }
 ```
 

--- a/sdk/typescript/src/api/transaction/types.ts
+++ b/sdk/typescript/src/api/transaction/types.ts
@@ -46,6 +46,12 @@ export interface Transaction {
   isNoop: boolean;
   externalId?: string | null;
   cancelledByTransactionId?: string | null;
+  /**
+   * Set when the node permanently rejected this transaction's payload and the queue
+   * replaced it with a same-nonce no-op; once that no-op mines the transaction
+   * resolves to FAILED carrying this reason.
+   */
+  failedReason?: string | null;
 }
 
 export interface TransactionToSend {


### PR DESCRIPTION
## Problem

Nonces are reserved at admission, so any path that terminally failed a transaction at send time without consuming its nonce on-chain permanently wedged the relayer: every transaction queued behind the dropped nonce could never mine. This happened on insufficient relayer funds, RPC/signer outages, Safe proxy read failures, and permanently rejected payloads. Separately, nonce desync recovery reassigned a fresh nonce without checking whether our own lost-response broadcast was what consumed the old one — risking duplicate execution of the payload.

## Changes

**Retry instead of fail for operator-fixable/transient errors.** Insufficient funds, gas estimation issues, conversion/signer errors, and Safe proxy errors at send time keep the nonce-holding transaction at the head of the pending queue and retry. Topping up the relayer drains the queue with no manual intervention. Queue processing loops back off 1s on errors instead of hot-looping.

**Close out permanently rejected payloads with a same-nonce no-op.** When the node says a payload can never execute (would revert, intrinsic gas too low, over the block gas cap, size caps), the transaction is marked FAILED — carrying the node's rejection reason in a new `failedReason` field (API + Rust/TS SDKs) — and converted in place to a same-nonce no-op self-send that consumes the reserved nonce. The failure webhook fires with the user's original payload; the no-op's mined receipt resolves the final status without a duplicate webhook.

**Prevent duplicate execution on nonce desync.** The hash of every ambiguous broadcast attempt (transport failure where the node may have accepted the send) is recorded in memory and the DB. On 'nonce too low', the queue checks that hash's receipt before reassigning a fresh nonce — if our own broadcast mined, it hands over to receipt resolution instead of re-executing the payload. 'already known' responses are treated as proof of a live broadcast and polled, never reassigned. Receipt-check failures fail closed.

**Central error classification.** `classify_send_error` is the single classification point for node send/estimate errors, with permanent rejections checked first so revert reasons quoting 'balance' or nonce wording ('execution reverted: invalid nonce') are never misrouted into funds handling or nonce resync. Covers geth/erigon/reth, Nethermind (camel-case wordings), Besu and OpenEthereum-style messages, with a unit test over all wordings.

**Block gas limit check is now advisory.** A stale cache or RPC blip can no longer fail a nonce-holding send; the node's own rejection is the authoritative signal. The cache serves a stale value on transient RPC failures.

## Tests

- New e2e suite `nonce_stuck.rs`: insufficient-funds-at-send retries until top-up, cancel no-op survives a drained balance, external nonce displacement recovers with a fresh nonce, and an on-chain revert consumes its nonce — each asserting the follow-up transaction still mines (no stranded nonce).
- Expired-transaction e2e now asserts nonce continuity after the expiry no-op.
- Unit test covering `classify_send_error` across client wordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)