### PR TITLE
feat: upgrade alloy to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ members = [
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.98"
-alloy = { version = "1.1.3", features = ["full", "signer-mnemonic", "signer-keystore", "eips", "eip712"] }
-alloy-rlp = "0.3.12"
-alloy-eips = "1.1.3"
+alloy = { version = "2", features = ["full", "signer-mnemonic", "signer-keystore", "eips", "eip712"] }
+alloy-rlp = "0.3.16"
+alloy-eips = "2"
 
 [profile.release]
 lto = "fat"

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -6,6 +6,7 @@
 
 ### Features
 
+- feat: upgrade alloy dependencies to version 2 for rust consumers
 - feat: add YAML-driven cron jobs for recurring relayer transactions and contract calls, with persisted last-run state across restarts
 - feat: run raw provider e2e tests in CI for pull requests and pushes
 - feat: expose failedReason on transactions so API and SDK consumers can read why a payload was permanently rejected


### PR DESCRIPTION
## Summary
- upgrade the workspace Alloy dependency to version 2
- align direct alloy-eips/alloy-rlp workspace dependencies with the resolved Alloy 2 graph
- add the required changelog entry

## Verification
- cargo check --workspace
- cargo fmt --all -- --check
- cargo clippy -- -D warnings -A clippy::uninlined_format_args
- cargo test --exclude rust-sdk-playground --workspace