### PR TITLE
fix: prevent docker cache export failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,8 +88,8 @@ jobs:
           platforms: linux/amd64
           provenance: mode=max
           sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-amd64
+          cache-to: type=gha,scope=docker-amd64,mode=max,ignore-error=true
 
   build-arm64:
     name: Build ARM64 Docker Image
@@ -158,8 +158,8 @@ jobs:
           platforms: linux/arm64
           provenance: mode=max
           sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-arm64
+          cache-to: type=gha,scope=docker-arm64,mode=max,ignore-error=true
 
   create-manifest:
     name: Create Multi-Arch Manifest

--- a/documentation/rrelayer/docs/pages/changelog.mdx
+++ b/documentation/rrelayer/docs/pages/changelog.mdx
@@ -11,6 +11,7 @@
 ### Bug fixes
 
 - fix: deploy documentation through github pages
+- fix: prevent docker cache export failures from blocking arm64 image publishing
 
 ---
 


### PR DESCRIPTION
## Summary
- add per-architecture GitHub Actions cache scopes for Docker builds
- make Docker cache export non-fatal so ARM64 image publishing is not blocked by GHA cache backend errors
- add changelog entry

## Verification
- ruby parsed `.github/workflows/docker.yml` and `.github/workflows/ci.yml`
- `git diff --check`
- `docker buildx build --platform linux/arm64 --load -t rrelayer:arm64-ci-cache-fix .` through the prebuilt-binary Dockerfile path